### PR TITLE
resolving 'Unable to find a suitable version for angular'

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,5 +28,8 @@
     },
     "devDependencies": {
         "jasmine": "1.3.1"
+    },
+    "resolutions": {
+        "angular": "1.0.7"
     }
 }


### PR DESCRIPTION
I got this (below) on a "bower install" on current master:

Unable to find a suitable version for angular, please choose one:
    1) angular#1.0.7 which resolved to 1.0.7 and has angular-mocks#1.0.7, angular-resource#1.0.7, angular-translate#1.0.2, angular-translate-loader-static-files#0.1.4, prototype-app as dependants
    2) angular#1.0.8 which resolved to 1.0.8 and has angular-sanitize#1.0.8 as dependants
    3) angular#~1.0 || ~1.1 which resolved to 1.0.8 and has angular-webstorage#0.9.3 as dependants
    4) angular#>=1 which resolved to 1.2.0-rc.3 and has angular-bootstrap#0.5.0 as dependants

Prefix the choice with ! to persist it to bower.json

Choice: !1

This pull request resolves this. Don't ask me how exactly - I don't have the faintest idea.. ;-) but it's what the !1 does.

PS: Actually the !1 reformats the bower.json completely - this PR is a manually edited version with just the diff. I'll send another separate PR with the complete reformatted version to make this easier in the future.
