### PR TITLE
Completely reformatted bower.json, by Bower choice !1 to resolve problem in Pull Request 197

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,32 +1,35 @@
 {
-    "name": "prototype-app",
-    "version": "0.0.0",
-    "ignore": [
-        "lib"
-    ],
-    "dependencies": {
-        "angular": "1.0.7",
-        "angular-resource": "1.0.7",
-        "angular-mocks": "1.0.7",
-        "angular-bootstrap": "0.5.0",
-        "angular-webstorage": "0.9.3",
-        "blockui": "2.55.0-2013.01.23",
-        "datatables": "1.9.4",
-        "jquery": "1.8.3",
-        "jquery-ui": "1.10.3",
-        "require-css": "0.0.7",
-        "require-less": "0.0.7",
-        "requirejs": "2.1.8",
-        "underscore": "1.5.1",
-        "angular-translate":"1.0.2",
-        "angular-translate-loader-static-files":"0.1.4",
-        "d3": "3.3.3",
-        "nvd3": "1.1.10-beta",
-        "angularjs-file-upload":"0.1.4",
-        "angular-sanitize":"v1.0.8",
-        "ckeditor":""
-    },
-    "devDependencies": {
-        "jasmine": "1.3.1"
-    }
+  "name": "prototype-app",
+  "version": "0.0.0",
+  "ignore": [
+    "lib"
+  ],
+  "dependencies": {
+    "angular": "1.0.7",
+    "angular-resource": "1.0.7",
+    "angular-mocks": "1.0.7",
+    "angular-bootstrap": "0.5.0",
+    "angular-webstorage": "0.9.3",
+    "blockui": "2.55.0-2013.01.23",
+    "datatables": "1.9.4",
+    "jquery": "1.8.3",
+    "jquery-ui": "1.10.3",
+    "require-css": "0.0.7",
+    "require-less": "0.0.7",
+    "requirejs": "2.1.8",
+    "underscore": "1.5.1",
+    "angular-translate": "1.0.2",
+    "angular-translate-loader-static-files": "0.1.4",
+    "d3": "3.3.3",
+    "nvd3": "1.1.10-beta",
+    "angularjs-file-upload": "0.1.4",
+    "angular-sanitize": "v1.0.8",
+    "ckeditor": ""
+  },
+  "devDependencies": {
+    "jasmine": "1.3.1"
+  },
+  "resolutions": {
+    "angular": "1.0.7"
+  }
 }


### PR DESCRIPTION
see https://github.com/openMF/prototype-app/pull/197 - this is what !1 actually did - it completely reformatted bower.json.

I've deliberately separate two separate PRs - the https://github.com/openMF/prototype-app/pull/197 shows the small change it actually did (addition of "resolutions"), while this one is the complete reformat. I'd recommend you integrate this, as it will make it much easier to diff the next time Bower offers to persist a choice.
