### PR TITLE
disburse loan payment type

### DIFF
--- a/app/scripts/controllers/loanAccount/LoanAccountActionsController.js
+++ b/app/scripts/controllers/loanAccount/LoanAccountActionsController.js
@@ -45,6 +45,7 @@
             scope.modelName = 'actualDisbursementDate';
             resourceFactory.loanTrxnsTemplateResource.get({loanId:scope.accountId, command:'disburse'}, function(data){
               scope.paymentTypes=data.paymentTypeOptions;
+              scope.formData.paymentTypeId = data.paymentTypeOptions[0].id;
               scope.formData[scope.modelName] = new Date();
             });
             scope.title = 'label.disburse.loan.account';

--- a/app/scripts/controllers/loanAccount/ViewLoanDetailsController.js
+++ b/app/scripts/controllers/loanAccount/ViewLoanDetailsController.js
@@ -218,21 +218,22 @@
         }
 
         if (data.status.value == "Approved") {
-            scope.buttons = { singlebuttons : [{
-                                name:"button.addloancharge",
-                                icon :"icon-plus-sign"
-                              },
+            scope.buttons = { singlebuttons : [
                               {
                                 name:"button.assignloanofficer",
                                 icon :"icon-user"
                               },
                               {
+                                name:"button.disburse",
+                                icon :"icon-flag"
+                              },
+                              {
                                 name:"button.undoapproval",
                                 icon :"icon-undo"
-                              },
+                              }
                             ],
                               options: [{
-                                name:"button.disburse"
+                                name:"button.addloancharge"
                               },
                               {
                                name:"button.guarantor"

--- a/app/views/loans/loanaccountactions.html
+++ b/app/views/loans/loanaccountactions.html
@@ -27,7 +27,7 @@
 
       <div ng-show="isTransaction">
         <div class="control-group">
-          <label class="control-label" for="paymentTypeId">{{ 'label.loan.account.paymentTypeId' | translate}}</label>
+          <label class="control-label" for="paymentTypeId">{{ 'label.loan.account.paymentTypeId' | translate}}<span class="required">*</span></label>
           <div class="controls">
             <select id="paymentTypeId" ng-model="formData.paymentTypeId" ng-options="paymentType.id as paymentType.name for paymentType in paymentTypes" value="{{paymentType.id}}"></select>
           </div>


### PR DESCRIPTION
In this  request disburse loan for `payment type` field shows default payment type `check` value and also in view loan, when loan waiting for disburse, 'disburse' button appearing in more options now i  replaced with 'add loan charge' button.
