### PR TITLE
view loan detail and closed a/c in view client changes

### DIFF
--- a/app/global-translations/locale-en.json
+++ b/app/global-translations/locale-en.json
@@ -875,6 +875,10 @@
     "label.heading.loanamountandbalance":"Loan Amount and Balance",
     "label.heading.totalcostofloan":"Total Cost of Loan",
     "label.heading.installmenttotals":"Installment Totals",
+    "label.heading.loan.onprincipalpayment":"On Principal Payment",
+    "label.heading.loan.oninterestpayment":"On Interest Payment",
+    "label.heading.loan.fund":"Fund",
+    "label.heading.loan.interestfreeperiod":"Interest-Free Period(s)",
 
     "#Anchors": "..",
     "label.anchor.viewloanaccount": "View Loan Account",

--- a/app/scripts/controllers/client/ViewClientController.js
+++ b/app/scripts/controllers/client/ViewClientController.js
@@ -240,6 +240,9 @@
         };
         scope.isNotClosed = function(loanaccount) {
           if(loanaccount.status.code === "loanStatusType.closed.written.off" || 
+            loanaccount.status.code === "loanStatusType.closed.obligations.met" || 
+            loanaccount.status.code === "loanStatusType.closed.reschedule.outstanding.amount" || 
+            loanaccount.status.code === "loanStatusType.withdrawn.by.client" || 
             loanaccount.status.code === "loanStatusType.rejected") {
             return false;
           } else{
@@ -248,7 +251,10 @@
         };
 
         scope.isClosed = function(loanaccount) {
-          if(loanaccount.status.code === "loanStatusType.closed.written.off" || 
+          if(loanaccount.status.code === "loanStatusType.closed.written.off" ||
+            loanaccount.status.code === "loanStatusType.closed.obligations.met" || 
+            loanaccount.status.code === "loanStatusType.closed.reschedule.outstanding.amount" || 
+            loanaccount.status.code === "loanStatusType.withdrawn.by.client" || 
             loanaccount.status.code === "loanStatusType.rejected") {
             return true;
           } else{

--- a/app/views/loans/editloanaccount.html
+++ b/app/views/loans/editloanaccount.html
@@ -158,8 +158,27 @@
                         </td>
                         <td>
                             <label class="control-label">{{ 'label.input.grace' | translate }}&nbsp;</label>
-                            <input id="graceOnPrincipalPayment" class="input-small" type="text" ng-model="formData.graceOnPrincipalPayment">
-                            <input id="graceOnInterestPayment" class="input-small" type="text" ng-model="formData.graceOnInterestPayment">
+                            <table>
+                              <tr>
+                                <td>
+                                  <input id="graceOnPrincipalPayment" class="input-small" type="text" ng-model="formData.graceOnPrincipalPayment">
+                                </td>
+                                <td>
+                                </td>
+                                <td>
+                                  <input id="graceOnInterestPayment" class="input-small" type="text" ng-model="formData.graceOnInterestPayment">
+                                </td>
+                              </tr>
+                              <tr>
+                                <td>
+                                  {{'label.heading.loan.onprincipalpayment' | translate}}
+                                </td>
+                                <td></td>
+                                <td>
+                                  {{'label.heading.loan.oninterestpayment' | translate}}
+                                </td>
+                              </tr>
+                            </table>
                         </td>
                     </tr>
                     <tr>
@@ -168,15 +187,12 @@
                             <input id="graceOnInterestCharged" type="text" ng-model="formData.graceOnInterestCharged">
                         </td>
                         <td>
-                            <label class="control-label">{{ 'label.input.interestchargedfrom' | translate }}&nbsp;</label>
-                            <input type="text" id="interestChargedFromDate" datepicker-pop="dd MMMM yyyy" ng-model="formData.interestChargedFromDate" is-open="opened2" min="minDate" max="'2020-06-22'" date-disabled="disabled(date, mode)" late-Validate />
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>
                             <label class="control-label">{{ 'label.input.firstrepaymenton' | translate }}&nbsp;</label>
                             <input type="text" id="repaymentsStartingFromDate" datepicker-pop="dd MMMM yyyy" ng-model="formData.repaymentsStartingFromDate" is-open="opened3" min="minDate" max="'2020-06-22'" date-disabled="disabled(date, mode)" late-Validate />
                         </td>
+                    </tr>
+                    <tr>
+                        
                         <td></td>
                     </tr>
                 </table>

--- a/app/views/loans/newloanaccount.html
+++ b/app/views/loans/newloanaccount.html
@@ -172,8 +172,22 @@
                   </td>
                   <td>
                     <label class="control-label">{{ 'label.input.grace' | translate }}&nbsp;</label>
-                    <input id="graceOnPrincipalPayment" class="input-small" type="text" ng-model="formData.graceOnPrincipalPayment">
-                    <input id="graceOnInterestPayment" class="input-small" type="text" ng-model="formData.graceOnInterestPayment">
+                    <table>
+                      <tr>
+                        <td>
+                          <input id="graceOnPrincipalPayment" class="input-small" type="text" ng-model="formData.graceOnPrincipalPayment">
+                        </td>
+                        <td></td>
+                        <td>
+                          <input id="graceOnInterestPayment" class="input-small" type="text" ng-model="formData.graceOnInterestPayment">
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>{{ 'label.heading.loan.onprincipalpayment' | translate }}&nbsp;</td>
+                        <td></td>
+                        <td>{{ 'label.heading.loan.oninterestpayment' | translate }}&nbsp;</td>
+                      </tr>
+                    </table>
                   </td>
                 </tr>
                 <tr>
@@ -182,19 +196,16 @@
                     <input id="graceOnInterestCharged" type="text" ng-model="formData.graceOnInterestCharged">
                   </td>
                   <td>
-                      <label class="control-label">{{ 'label.input.interestchargedfrom' | translate }}&nbsp;</label>
-                      <input id="interestChargedFromDate" type="text" datepicker-pop="dd MMMM yyyy" ng-model="date.third" is-open="opened2" min="minDate" max="'2020-06-22'"/>
+                      <label class="control-label">{{ 'label.input.firstrepaymenton' | translate }}&nbsp;</label>
+                      <input id="repaymentsStartingFromDate" type="text" datepicker-pop="dd MMMM yyyy" ng-model="date.fourth" is-open="opened3" min="minDate" max="'2020-06-22'"/>
                   </td>
                 </tr>
                 <tr>
                   <td>
-                      <label class="control-label">{{ 'label.input.firstrepaymenton' | translate }}&nbsp;</label>
-                      <input id="repaymentsStartingFromDate" type="text" datepicker-pop="dd MMMM yyyy" ng-model="date.fourth" is-open="opened3" min="minDate" max="'2020-06-22'"/>
-                  </td>
-                  <td>
                       <label class="control-label">{{ 'label.input.linksavings' | translate }}&nbsp;</label>
                       <select id="linkAccountId" ng-model="formData.linkAccountId" ng-options="savingaccount.id as savingaccount.productName for savingaccount in loanaccountinfo.accountLinkingOptions" value="{{savingaccount.id}}"/>
                   </td>
+                  <td></td>
                 </tr>
               </table>
             </td>

--- a/app/views/loans/viewloanaccountdetails.html
+++ b/app/views/loans/viewloanaccountdetails.html
@@ -76,7 +76,7 @@
                 </tr>
                 <tr>
                   <td>{{'label.heading.interest' | translate}}:</td>
-                  <td>{{loandetails.annualInterestRate}} per annum ({{loandetails.interestRatePerPeriod}}%&nbsp; {{loandetails.interestRateFrequencyType.value}} - {{loandetails.interestType.value}}</td>
+                  <td>{{loandetails.annualInterestRate}} per annum ({{loandetails.interestRatePerPeriod}}%&nbsp; {{loandetails.interestRateFrequencyType.value}}) - {{loandetails.interestType.value}}</td>
                 </tr>
                 <tr>
                   <td>{{'label.heading.graceonprincipalpayment' | translate}}</td>
@@ -84,7 +84,15 @@
                 </tr>
                 <tr>
                   <td>{{'label.heading.graceoninterestpayment' | translate}}</td>
-                  <td>{{loandetails.timeline.approvedOnDate | DateFormat}}</td>
+                  <td>{{loandetails.graceOnInterestPayment}}</td>
+                </tr>
+                <tr>
+                  <td>{{'label.heading.loan.fund' | translate}}</td>
+                  <td>{{loandetails.fundName}}</td>
+                </tr>
+                <tr>
+                  <td>{{'label.heading.loan.interestfreeperiod' | translate}}</td>
+                  <td>{{loandetails.graceOnInterestCharged}}</td>
                 </tr>
                 <tr>
                   <td>{{'label.heading.submittedondate' | translate}}</td>
@@ -101,10 +109,6 @@
                 <tr>
                   <td>{{'label.heading.matureson' | translate}}</td>
                   <td>{{loandetails.timeline.expectedMaturityDate | DateFormat}}</td>
-                </tr>
-                <tr>
-                  <td>{{'label.heading.interestChargedFrom' | translate}}</td>
-                  <td>{{loandetails.timeline.interestChargedFromDate | DateFormat}}</td>
                 </tr>
             </table>
           </div>


### PR DESCRIPTION
In this changes 'Interest charged from`is removed in all places, and for`grace`field  'On principal payment`,`On interest payment` labels is added, and in view client before `Closed loans (Closed (obligations met), Closed (rescheduled) etc) are displayed under active loan accounts tab` are closed a/c tab.
