### PR TITLE
Add grunt tasks for easier development

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,8 +1,8 @@
-
 'use strict';
 
 module.exports = function(grunt) {
-
+  // Load grunt tasks automatically
+  require('load-grunt-tasks')(grunt);
   // Project configuration.
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
@@ -14,14 +14,66 @@ module.exports = function(grunt) {
       target: 'community-app',
       test: 'test'
     },
-
+    watch: {
+        js: {
+            files: ['<%= mifosx.app %>/scripts/**/*.js'],
+            options: {
+                livereload: true
+            }
+        },
+        gruntfile: {
+            files: ['Gruntfile.js']
+        },
+        livereload: {
+            options: {
+                livereload: '<%= connect.options.livereload %>'
+            },
+            files: [
+                '<%= mifosx.app %>/**/*.html',
+                '<%= mifosx.app %>/{,*/}*.json',
+                '<%= mifosx.app %>/**/*.js',
+                '<%= mifosx.app %>/**/*.css',
+                '<%= mifosx.app %>/images/{,*/}*.{png,jpg,jpeg,gif,webp,svg}'
+            ]
+        }
+    },
+     // The actual grunt server settings
+    connect: {
+        options: {
+            port:  9000,
+            hostname: '0.0.0.0',
+            livereload: 35729,
+            open:'http://<%= connect.options.hostname %>:<%= connect.options.port %>?baseApiUrl=https://demo.openmf.org'
+        },
+        livereload: {
+            options: {
+                base: [
+                    '.tmp',
+                    '<%= mifosx.app %>'
+                ]
+            }
+        }
+    },
+    // w3c html calidation
+    validation: {
+        options: {
+            reset: true,
+            relaxerror: ['no document type declaration; will parse without validation', 'document type does not allow element \\"[A-Z]+\\" here']
+        },
+        files: {
+            src: [
+                '<%= mifosx.app  %>/views/{,*/}*.html', // Validating templates may not be of much use.
+                '<%= mifosx.app  %>/index.html'
+                ]
+        }
+    },
     // Make sure code styles are up to par and there are no obvious mistakes
     jshint: {
       options: {
-        node: true,
-        jshintrc: true,
-        reporter:'checkstyle',
-        reporterOutput:'jshint-log.xml'
+        jshintrc: '.jshintrc',
+        reporter: require('jshint-stylish'),
+        reporterOutput:'jshint-log.xml',
+        force: true
       },
       all: ['Gruntfile.js', '<%= mifosx.app %>/scripts/**/*.js']
     },
@@ -67,7 +119,8 @@ module.exports = function(grunt) {
             '!<%= mifosx.dist %>/.git*'
           ]
         }]
-      }
+      },
+      server: '.tmp'
     },
 
     // Copies remaining files to places other tasks can use
@@ -123,7 +176,7 @@ module.exports = function(grunt) {
           cwd: '<%= mifosx.app %>/bower_components',
           dest: '<%= mifosx.dist %>/<%=mifosx.target%>/bower_components',
           src: [
-            '**/*min.js', 'require-css/*.js', 'require-less/*.js', 
+            '**/*min.js', 'require-css/*.js', 'require-less/*.js',
             '!jasmine/**', '!requirejs/**/**', 'requirejs/require.js', '!underscore/**'
           ]
         }
@@ -158,7 +211,15 @@ module.exports = function(grunt) {
             '**/**'
           ]
         }]
-      }
+      },
+        // this won't be necessary after fixing dependencies
+        server: {
+            expand: true,
+            dot: true,
+            cwd: '<%= mifosx.test %>',
+            dest: '.tmp/test',
+            src: '**/**'
+        }
     },
 
       //hashing css & js
@@ -209,7 +270,6 @@ module.exports = function(grunt) {
               }]
           }
       },
-    
     // concatinate JS files
     /** FIXME: Address issues with this task**/
     concat: {
@@ -225,8 +285,8 @@ module.exports = function(grunt) {
           //'<%= mifosx.dist %>/<%=mifosx.target%>/scripts/services/services.js': ['<%= mifosx.app %>/scripts/services/**/*.js'],
           '<%= mifosx.dist %>/<%=mifosx.target%>/scripts/filters/filters.js': ['<%= mifosx.app %>/scripts/filters/**/*.js'],
           '<%= mifosx.dist %>/<%=mifosx.target%>/scripts/routes-initialTasks-webstorage-configuration.js':
-            ['<%= mifosx.app %>/scripts/routes.js', 
-            '<%= mifosx.app %>/scripts/initialTasks.js', 
+            ['<%= mifosx.app %>/scripts/routes.js',
+            '<%= mifosx.app %>/scripts/initialTasks.js',
             '<%= mifosx.app %>/scripts/webstorage-configuration.js']
         }
       }
@@ -264,23 +324,15 @@ module.exports = function(grunt) {
     }
   });
 
-  // Load the plugin that provides the "uglify" task.
-  grunt.loadNpmTasks('grunt-contrib-uglify');
-  grunt.loadNpmTasks('grunt-contrib-clean');
-  grunt.loadNpmTasks('grunt-contrib-copy');
-  grunt.loadNpmTasks('grunt-contrib-concat');
-  grunt.loadNpmTasks('grunt-contrib-requirejs');
-  grunt.loadNpmTasks('grunt-contrib-jshint');
-  grunt.loadNpmTasks('grunt-karma');
-  grunt.loadNpmTasks('grunt-devcode');
-  grunt.loadNpmTasks('grunt-hashres');
-  grunt.loadNpmTasks('grunt-text-replace');
+
+  // Run development server using grunt serve
+  grunt.registerTask('serve', ['clean:server', 'copy:server', 'connect:livereload', 'watch']);
+  // Validate JavaScript and HTML files
+  grunt.registerTask('validate', ['jshint:all', 'validation']);
   // Default task(s).
-      
   grunt.registerTask('default', ['clean', 'jshint', 'copy:dev']);
   grunt.registerTask('prod', ['clean', 'copy:prod', 'concat', 'uglify:prod', 'devcode:dist', 'hashres','replace']);
   grunt.registerTask('dev', ['clean', 'copy:dev']);
-  grunt.registerTask('compile', ['jshint']);
   grunt.registerTask('test', ['karma']);
 
 };

--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ npm install -g grunt-cli
 
 5. Check the backend server HOST settings in the community-app\app\scripts\modules\configuration.js file. If you are connecting to a non local host, then you may need to change the API_URL_OVERRIDE value to *false*.
 
-6. Now open the 'index.html' file in FIREFOX browser. 
+6. To preview the app run
+```
+ grunt serve
+```
+   or open the 'index.html' file in FIREFOX browser.
 
 7. Default username/password: mifos/password. This application will hit the demo server by default.
 
@@ -63,12 +67,13 @@ Grunt tasks are used to automate repetitive tasks like minification, compilation
 
 Following are the tasks integrated.
 
-### Compilation
+### Validate JS and HTML files
 
-Compile the JS files to detect errors and potential problems in JavaScript code. All errors output will be written to jshint-log.xml file which get created under project base directory.
+Validate the JS files to detect errors and potential problems in JavaScript code. All errors output will be written to jshint-log.xml file which get created under project base directory.
+Checks the markup validity of HTML files. All errors output will be written to console.
 
 ```
-grunt compile
+grunt validate
 ```
 
 ### Build
@@ -79,6 +84,14 @@ Build the code for production deployment.
 grunt prod
 ```
 
+### Serve
+
+Use this for development.
+Start a static server and open the project in the default browser. The application will hit the demo server.
+
+```
+grunt serve
+```
 
 ## Running the tests
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-concat": "~0.3.0",
+    "grunt-contrib-connect": "~0.5.0",
     "grunt-contrib-requirejs": "~0.3.1",
+    "grunt-contrib-watch": "~0.5.2",
     "karma-script-launcher": "~0.1.0",
     "karma-chrome-launcher": "~0.1.1",
     "karma-html2js-preprocessor": "~0.1.0",
@@ -26,7 +28,10 @@
     "grunt-replace": "~0.5.1",
     "grunt-string-replace": "~0.2.7",
     "grunt-text-replace": "~0.3.10",
-    "grunt-hashres": "~0.3.4"
+    "grunt-hashres": "~0.3.4",
+    "grunt-html-validation": "~0.1.13",
+    "load-grunt-tasks": "~0.4.0",
+    "jshint-stylish": "~0.1.5"
   },
   "scripts": {
     "test": "grunt test --verbose"


### PR DESCRIPTION
Use this for development.
Start a static server and open the project in the default browser. The application will hit the demo server.

```
grunt serve
```

Validate the JS files to detect errors and potential problems in JavaScript code.
Checks the markup validity of HTML files. All errors output will be written to console.

```
grunt validate
```
