### PR TITLE
Wire in karma-coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ dist
 atlassian-ide-plugin.xml
 .tmp
 jshint-log.xml
+karma-reports

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -24,7 +24,24 @@ module.exports = function (config) {
 
         // test results reporter to use
         // possible values: dots || progress || growl
-        reporters : ['progress'],
+        reporters : ['progress', 'coverage'],
+
+        preprocessors: {
+          './app/scripts/**/*.js' : ['coverage']
+        },
+
+        junitReporter : {
+            outputFile: 'karma-reports/test-unit.xml',
+            suite: 'unit'
+        },
+
+        coverageReporter: {
+          reporters:[
+            {type : 'cobertura', dir : 'karma-reports/'},
+            {type : 'text',      dir : 'karma-reports/', file : 'coverage.txt'},
+            {type : 'html',      dir : 'karma-reports/' }
+          ]
+        },
 
         // web server port
         port : 8080,

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "grunt-hashres": "~0.3.4",
     "grunt-html-validation": "~0.1.13",
     "load-grunt-tasks": "~0.4.0",
-    "jshint-stylish": "~0.1.5"
+    "jshint-stylish": "~0.1.5",
+    "karma-coverage": "~0.2.1",
+    "karma-junit-reporter": "~0.2.1"
   },
   "scripts": {
     "test": "grunt test --verbose"


### PR DESCRIPTION
karma-coverage has been configured to output simple text and HTML reports to "karma-reports" directory.

For more info, visit karma-coverage project home: https://github.com/karma-runner/karma-coverage
