### PR TITLE
Select staff only from the branch office

### DIFF
--- a/app/scripts/controllers/client/ClientActionsController.js
+++ b/app/scripts/controllers/client/ClientActionsController.js
@@ -29,7 +29,7 @@
                     scope.breadcrumbName = 'label.anchor.assignstaff';
                     scope.labelName = 'label.input.staff';
                     scope.staffField = true;
-                    resourceFactory.clientResource.get({clientId: routeParams.id, template: 'true'}, function (data) {
+                    resourceFactory.clientResource.get({clientId: routeParams.id, template: 'true',staffInSelectedOfficeOnly:true}, function (data) {
                         if (data.staffOptions) {
                             scope.staffOptions = data.staffOptions;
                             scope.formData.staffId = scope.staffOptions[0].id;

--- a/app/scripts/controllers/groups/AssignStaffController.js
+++ b/app/scripts/controllers/groups/AssignStaffController.js
@@ -4,7 +4,7 @@
             scope.group = [];
             scope.staff = [];
             scope.formData = {};
-            resourceFactory.assignStaffResource.get({groupOrCenter: routeParams.entityType, groupOrCenterId: routeParams.id, template: 'true'}, function (data) {
+            resourceFactory.assignStaffResource.get({groupOrCenter: routeParams.entityType, groupOrCenterId: routeParams.id, template: 'true',staffInSelectedOfficeOnly:true}, function (data) {
                 scope.group = data;
                 scope.staffs = data.staffOptions;
                 scope.formData.staffId = data.staffOptions[0].id;

--- a/app/scripts/controllers/loanAccount/AssignLoanOfficerController.js
+++ b/app/scripts/controllers/loanAccount/AssignLoanOfficerController.js
@@ -7,7 +7,7 @@
             scope.loanId = routeParams.id;
             var fields = "id,loanOfficerId,loanOfficerOptions";
 
-            resourceFactory.loanResource.get({loanId: scope.loanId, template: true, fields: fields}, function (data) {
+            resourceFactory.loanResource.get({loanId: scope.loanId, template: true, fields: fields, staffInSelectedOfficeOnly:true}, function (data) {
                 if (data.loanOfficerOptions) {
                     scope.loanOfficers = data.loanOfficerOptions;
                     scope.formData.toLoanOfficerId = data.loanOfficerOptions[0].id;


### PR DESCRIPTION
@vishwas,

Assigning staff has three entry points

1) Creating client/group/center/loan/saving
2) Updating/Editing client/group/center/loan
3) Assign staff api for client/group/center/loan

I had missed to updating staffInSelectedOfficeOnly:true for 3rd entry point.
And this pull request is fix for the same.

Also I noticed, there is no option to update staff for saving account. Asked Subbu to look into it.
