### PR TITLE
MIFOSX-1516

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -45,8 +45,7 @@ module.exports = function(grunt) {
             port:  9000,
             hostname: 'localhost',
             livereload: 35729,
-            //open:'http://<%= connect.options.hostname %>:<%= connect.options.port %>?baseApiUrl=https://demo.openmf.org'
-            open:'http://<%= connect.options.hostname %>:<%= connect.options.port %>?baseApiUrl=https://localhost:8443/mifosng-provider'
+            open:'http://<%= connect.options.hostname %>:<%= connect.options.port %>?baseApiUrl=https://demo.openmf.org'            
         },
         livereload: {
             options: {


### PR DESCRIPTION
https://mifosforge.jira.com/browse/MIFOSX-1516

Adding a watch files parameter to ignore everything under the bower_components directory helped with the CPU usage dramatically. On my machine it has gone from nearly 25% sustained to almost zero.
