### PR TITLE
MIFOSX-1687 Retain Search Criteria (and formatting)

### DIFF
--- a/app/scripts/controllers/accounting/SearchTransactionController.js
+++ b/app/scripts/controllers/accounting/SearchTransactionController.js
@@ -1,7 +1,6 @@
 (function (module) {
     mifosX.controllers = _.extend(module, {
         SearchTransactionController: function (scope, resourceFactory, paginatorService, dateFilter, location) {
-
             scope.filters = [
                 {option: "All", value: ""},
                 {option: "Manual Entries", value: true},
@@ -17,13 +16,28 @@
             scope.routeTo = function (id) {
                 location.path('/viewtransactions/' + id);
             };
-            resourceFactory.accountCoaResource.getAllAccountCoas({manualEntriesAllowed: true, usage: 1, disabled: false}, function (data) {
+            resourceFactory.accountCoaResource.getAllAccountCoas({
+                manualEntriesAllowed: true,
+                usage: 1,
+                disabled: false
+            }, function (data) {
                 scope.glAccounts = data;
             });
 
             resourceFactory.officeResource.getAllOffices(function (data) {
                 scope.offices = data;
             });
+
+            if (!scope.searchCriteria.journals) {
+                scope.searchCriteria.journals = [null, null, null, null, null, null];
+                scope.saveSC();
+            }
+            scope.formData.transactionId = scope.searchCriteria.journals[0];
+            scope.formData.glAccount = scope.searchCriteria.journals[1];
+            scope.formData.officeId = scope.searchCriteria.journals[2];
+            scope.formData.manualEntriesOnly = scope.searchCriteria.journals[3];
+            scope.date.first = scope.searchCriteria.journals[4];
+            scope.date.second = scope.searchCriteria.journals[5];
 
             var fetchFunction = function (offset, limit, callback) {
                 var reqFirstDate = dateFilter(scope.date.first, scope.df);
@@ -36,28 +50,41 @@
 
                 if (scope.formData.transactionId) {
                     params.transactionId = scope.formData.transactionId;
-                }
+                    scope.searchCriteria.journals[0] = params.transactionId;
+                } else
+                    scope.searchCriteria.journals[0] = null;
 
                 if (scope.formData.glAccount) {
-                    params.glAccountId = scope.formData.glAccount.id;
-                }
+                    params.glAccountId = scope.formData.glAccount;
+                    scope.searchCriteria.journals[1] = params.glAccountId;
+                } else
+                    scope.searchCriteria.journals[1] = null;
 
                 if (scope.formData.officeId) {
                     params.officeId = scope.formData.officeId;
-                }
+                    scope.searchCriteria.journals[2] = params.officeId;
+                } else
+                    scope.searchCriteria.journals[2] = null;
 
                 if (scope.formData.manualEntriesOnly == true || scope.formData.manualEntriesOnly == false) {
                     params.manualEntriesOnly = scope.formData.manualEntriesOnly;
-                }
+                    scope.searchCriteria.journals[3] = params.manualEntriesOnly;
+                } else
+                    scope.searchCriteria.journals[3] = null;
 
                 if (scope.date.first) {
                     params.fromDate = reqFirstDate;
-                }
+                    scope.searchCriteria.journals[4] = params.fromDate;
+                } else
+                    scope.searchCriteria.journals[4] = null;
 
                 if (scope.date.second) {
                     params.toDate = reqSecondDate;
-                }
+                    scope.searchCriteria.journals[5] = params.toDate;
+                } else
+                    scope.searchCriteria.journals[5] = null;
 
+                scope.saveSC();
                 resourceFactory.journalEntriesResource.search(params, callback);
             };
 

--- a/app/scripts/controllers/collection/CollectionSheetController.js
+++ b/app/scripts/controllers/collection/CollectionSheetController.js
@@ -49,14 +49,13 @@
                 }
             };
 
-            if (localStorageService.get('Success') === 'true') {
+            if (localStorageService.getFromLocalStorage('Success') === 'true') {
                 scope.savesuccess = true;
-                localStorageService.remove('Success');
+                localStorageService.removeFromLocalStorage('Success');
                 scope.val = true;
                 $timeout(function () {
                     scope.val = false;
                 }, 3000);
-
             }
 
             scope.loanOfficerSelected = function (loanOfficerId) {
@@ -407,12 +406,12 @@
                 scope.formData.bulkSavingsDueTransactions = scope.bulkSavingsDueTransactions;
                 if (centerOrGroupResource === "centerResource") {
                     resourceFactory.centerResource.save({'centerId': scope.centerId, command: 'saveCollectionSheet'}, scope.formData, function (data) {
-                        localStorageService.add('Success', true);
+                        localStorageService.addToLocalStorage('Success', true);
                         route.reload();
                     });
                 } else if (centerOrGroupResource === "groupResource") {
                     resourceFactory.groupResource.save({'groupId': scope.groupId, command: 'saveCollectionSheet'}, scope.formData, function (data) {
-                        localStorageService.add('Success', true);
+                        localStorageService.addToLocalStorage('Success', true);
                         route.reload();
                     });
                 }

--- a/app/scripts/controllers/main/MainController.js
+++ b/app/scripts/controllers/main/MainController.js
@@ -6,14 +6,25 @@
             scope.domReady = true;
             scope.activity = {};
             scope.activityQueue = [];
-            if (localStorageService.get('Location')) {
-                scope.activityQueue = localStorageService.get('Location');
+            if (localStorageService.getFromLocalStorage('Location')) {
+                scope.activityQueue = localStorageService.getFromLocalStorage('Location');
             }
+            scope.loadSC = function () {
+                if (!localStorageService.getFromLocalStorage('searchCriteria'))
+                    localStorageService.addToLocalStorage('searchCriteria', {})
+                scope.searchCriteria = localStorageService.getFromLocalStorage('searchCriteria');
+            };
+            scope.saveSC = function () {
+                if (!localStorageService.getFromLocalStorage('searchCriteria'))
+                    localStorageService.addToLocalStorage('searchCriteria', {})
+                localStorageService.addToLocalStorage('searchCriteria', scope.searchCriteria);
+            };
+            scope.loadSC();
             scope.setDf = function () {
-                if (localStorageService.get('dateformat')) {
-                    scope.dateformat = localStorageService.get('dateformat');
+                if (localStorageService.getFromLocalStorage('dateformat')) {
+                    scope.dateformat = localStorageService.getFromLocalStorage('dateformat');
                 } else {
-                    localStorageService.add('dateformat', 'dd MMMM yyyy');
+                    localStorageService.addToLocalStorage('dateformat', 'dd MMMM yyyy');
                     scope.dateformat = 'dd MMMM yyyy';
                 }
                 scope.df = scope.dateformat;
@@ -21,14 +32,14 @@
             scope.setDf();
             $rootScope.setPermissions = function (permissions) {
                 $rootScope.permissionList = permissions;
-                localStorageService.add('userPermissions', permissions);
+                localStorageService.addToLocalStorage('userPermissions', permissions);
                 $rootScope.$broadcast('permissionsChanged')
             };
 
             $rootScope.hasPermission = function (permission) {
                 permission = permission.trim();
                 //FYI: getting all permissions from localstorage, because if scope changes permissions array will become undefined
-                $rootScope.permissionList = localStorageService.get('userPermissions');
+                $rootScope.permissionList = localStorageService.getFromLocalStorage('userPermissions');
                 //If user is a Super user return true
                 if ($rootScope.permissionList && _.contains($rootScope.permissionList, "ALL_FUNCTIONS")) {
                     return true;
@@ -55,7 +66,7 @@
             }, function () {
                 scope.activity = location.path();
                 scope.activityQueue.push(scope.activity);
-                localStorageService.add('Location', scope.activityQueue);
+                localStorageService.addToLocalStorage('Location', scope.activityQueue);
             });
 
             //Logout the user if Idle
@@ -67,7 +78,7 @@
             });
 
             // Log out the user when the window/tab is closed.
-            window.onunload = function() {
+            window.onunload = function () {
                 scope.logout();
                 $idle.unwatch();
                 scope.started = false;
@@ -91,17 +102,18 @@
                         $rootScope.setPermissions(scope.currentSession.user.userPermissions);
                     }
                     location.path('/home').replace();
-                } else{
-                     scope.loggedInUserId = data.userId;
-                };
+                } else {
+                    scope.loggedInUserId = data.userId;
+                }
+                ;
             });
 
             scope.search = function () {
                 location.path('/search/' + scope.search.query);
             };
             scope.text = '<span>Mifos X is designed by the <a href="http://www.openmf.org/">Mifos Initiative</a>.' +
-                '<a href="http://mifos.org/resources/community/"> A global community </a> thats aims to speed the elimination of poverty by enabling Organizations to more effectively and efficiently deliver responsible financial services to the world’s poor and unbanked </span><br/>' +
-                '<span>Sounds interesting?<a href="http://mifos.org/take-action/volunteer/"> Get involved!</a></span>';
+            '<a href="http://mifos.org/resources/community/"> A global community </a> thats aims to speed the elimination of poverty by enabling Organizations to more effectively and efficiently deliver responsible financial services to the world’s poor and unbanked </span><br/>' +
+            '<span>Sounds interesting?<a href="http://mifos.org/take-action/volunteer/"> Get involved!</a></span>';
 
             scope.logout = function () {
                 scope.currentSession = sessionManager.clear();
@@ -110,8 +122,8 @@
             };
 
             scope.langs = mifosX.models.Langs;
-            if (localStorageService.get('Language')) {
-                var temp = localStorageService.get('Language');
+            if (localStorageService.getFromLocalStorage('Language')) {
+                var temp = localStorageService.getFromLocalStorage('Language');
                 for (var i in mifosX.models.Langs) {
                     if (mifosX.models.Langs[i].code == temp.code) {
                         scope.optlang = mifosX.models.Langs[i];
@@ -222,7 +234,7 @@
             });
             scope.changeLang = function (lang, $event) {
                 translate.uses(lang.code);
-                localStorageService.add('Language', lang);
+                localStorageService.addToLocalStorage('Language', lang);
                 tmhDynamicLocale.set(lang.code);
                 scope.optlang = lang;
             };
@@ -232,23 +244,23 @@
                 scope.start(scope.currentSession);
                 if (session.user != null && session.user.userPermissions) {
                     $rootScope.setPermissions(session.user.userPermissions);
-                    localStorageService.add('userPermissions', session.user.userPermissions);
+                    localStorageService.addToLocalStorage('userPermissions', session.user.userPermissions);
                 }
                 ;
             });
         }
     });
     mifosX.ng.application.controller('MainController', [
-            '$scope',
-            '$location',
-            'SessionManager',
-            '$translate',
-            '$rootScope',
-            'localStorageService',
-            'keyboardManager', '$idle',
-            'tmhDynamicLocale',
-            mifosX.controllers.MainController
-        ]).run(function ($log) {
-            $log.info("MainController initialized");
-        });
+        '$scope',
+        '$location',
+        'SessionManager',
+        '$translate',
+        '$rootScope',
+        'localStorageService',
+        'keyboardManager', '$idle',
+        'tmhDynamicLocale',
+        mifosX.controllers.MainController
+    ]).run(function ($log) {
+        $log.info("MainController initialized");
+    });
 }(mifosX.controllers || {}));

--- a/app/scripts/controllers/main/ProfileController.js
+++ b/app/scripts/controllers/main/ProfileController.js
@@ -1,7 +1,7 @@
 (function (module) {
     mifosX.controllers = _.extend(module, {
         ProfileController: function (scope, localStorageService, resourceFactory, $modal) {
-            scope.userDetails = localStorageService.get('userData');
+            scope.userDetails = localStorageService.getFromLocalStorage('userData');
             resourceFactory.userListResource.get({userId: scope.userDetails.userId}, function (data) {
                 scope.user = data;
             });

--- a/app/scripts/controllers/main/RichDashboard.js
+++ b/app/scripts/controllers/main/RichDashboard.js
@@ -3,7 +3,7 @@
         RichDashboard: function (scope, resourceFactory, localStorageService, $rootScope, location) {
         	
         	scope.recent = [];
-            scope.recent = localStorageService.get('Location');
+            scope.recent = localStorageService.getFromLocalStorage('Location');
             scope.recentEight = [];
             scope.frequent = [];
             scope.recentArray = [];

--- a/app/scripts/controllers/reports/XBRLController.js
+++ b/app/scripts/controllers/reports/XBRLController.js
@@ -39,9 +39,9 @@
 
             });
 
-            if (localStorageService.get('XbrlReportSaveSuccess') == 'true') {
+            if (localStorageService.getFromLocalStorage('XbrlReportSaveSuccess') == 'true') {
                 scope.savesuccess = true;
-                localStorageService.remove('XbrlReportSaveSuccess');
+                localStorageService.removeFromLocalStorage('XbrlReportSaveSuccess');
                 scope.XbrlSuccess = true;
                 $timeout(function () {
                     scope.XbrlSuccess = false;
@@ -114,7 +114,7 @@
                 serialObject["config"] = JSON.stringify(config);
                 serialObject["identifier"] = "default";
                 resourceFactory.xbrlMixMappingResource.update({}, JSON.stringify(serialObject), function (data) {
-                    localStorageService.add('XbrlReportSaveSuccess', true);
+                    localStorageService.addToLocalStorage('XbrlReportSaveSuccess', true);
                     route.reload();
                 });
             };

--- a/app/scripts/controllers/system/AuditController.js
+++ b/app/scripts/controllers/system/AuditController.js
@@ -1,127 +1,150 @@
 (function (module) {
     mifosX.controllers = _.extend(module, {
-        AuditController: function (scope, resourceFactory,paginatorService, dateFilter, location) {
+        AuditController: function (scope, resourceFactory, paginatorService, dateFilter, location) {
             scope.formData = [];
             scope.isCollapsed = true;
             scope.date = {};
             scope.audit = [];
             scope.searchData = [];
 
-            resourceFactory.auditResource.get({templateResource: 'searchtemplate'}, function (data) {
-                scope.template = data;
-            });
-            scope.viewUser = function (item) {
-                scope.userTypeahead = true;
-                scope.formData.user = item.id;
-            };
-
             scope.routeTo = function (id) {
                 location.path('viewaudit/' + id);
             };
 
-            scope.search = function(){
-                scope.audit = paginatorService.paginate(fetchFunction, 14);
+            resourceFactory.auditResource.get({templateResource: 'searchtemplate'}, function (data) {
+                scope.template = data;
+            });
+
+            scope.viewUser = function (item) {
+                scope.formData.user = item.id;
             };
 
-            var fetchFunction = function (offset, limit,callback) {
+            if (!scope.searchCriteria.audit) {
+                scope.searchCriteria.audit = [null, null, null, null, null, null, null, null, null, null];
+                scope.saveSC();
+            }
+            scope.formData.user = scope.searchCriteria.audit[0];
+            scope.date.first = scope.searchCriteria.audit[1];
+            scope.date.third = scope.searchCriteria.audit[2];
+            scope.formData.status = scope.searchCriteria.audit[3];
+            if (scope.searchCriteria.audit[4])
+                scope.formData.action = scope.searchCriteria.audit[4];
+            scope.formData.resourceId = scope.searchCriteria.audit[5];
+            scope.date.second = scope.searchCriteria.audit[6];
+            scope.date.fourth = scope.searchCriteria.audit[7];
+            if (scope.searchCriteria.audit[8])
+                scope.formData.entity = scope.searchCriteria.audit[8];
+            if (scope.searchCriteria.audit[9])
+                scope.formData.checkedBy = scope.searchCriteria.audit[9];
+
+            var fetchFunction = function (offset, limit, callback) {
                 scope.isCollapsed = true;
                 scope.displayResults = true;
-                var reqFirstDate = dateFilter(scope.date.first, 'yyyy-MM-dd');
-                var reqSecondDate = dateFilter(scope.date.second, 'yyyy-MM-dd');
-                var reqThirdDate = dateFilter(scope.date.third, 'yyyy-MM-dd');
-                var reqFourthDate = dateFilter(scope.date.fourth, 'yyyy-MM-dd');
+                var reqFirstDate = dateFilter(scope.date.first, scope.df);
+                var reqSecondDate = dateFilter(scope.date.second, scope.df);
+                var reqThirdDate = dateFilter(scope.date.third, scope.df);
+                var reqFourthDate = dateFilter(scope.date.fourth, scope.df);
 
                 var params = {};
-                    params.offset = offset;
-                    params.limit = limit;
-                    params.paged = true;
-
-                if (scope.formData.action) {
-                    params.actionName = scope.formData.action;
-                }
-                ;
-
-                if (scope.formData.entity) {
-                    params.entityName = scope.formData.entity;
-                }
-                ;
-
-                if (scope.formData.status) {
-                    params.processingResult = scope.formData.status;
-                }
-                ;
-
-                if (scope.formData.status == 0) {
-                    params.processingResult = scope.formData.status;
-                }
-                ;
-
-                if (scope.formData.resourceId) {
-                    params.resourceId = scope.formData.resourceId;
-                }
-                ;
+                params.offset = offset;
+                params.limit = limit;
+                params.paged = true;
 
                 if (scope.formData.user) {
+                    if (scope.formData.user != parseInt(scope.formData.user)) {
+                        for (var i = 0; i < scope.template.appUsers.length; i++) {
+                            if (scope.formData.user == scope.template.appUsers[i].username)
+                                scope.formData.user = scope.template.appUsers[i].id;
+                        }
+                    }
                     params.makerId = scope.formData.user;
-                }
-                ;
+                    scope.searchCriteria.audit[0] = params.makerId;
+                } else
+                    scope.searchCriteria.audit[0] = null;
 
                 if (scope.date.first) {
                     params.makerDateTimeFrom = reqFirstDate;
-                }
-                ;
-
-                if (scope.date.second) {
-                    params.makerDateTimeTo = reqSecondDate;
-                }
-                ;
-
-                if (scope.formData.checkedBy) {
-                    params.checkerId = scope.formData.checkedBy;
-                }
-                ;
+                    scope.searchCriteria.audit[1] = params.makerDateTimeFrom;
+                } else
+                    scope.searchCriteria.audit[1] = null;
 
                 if (scope.date.third) {
                     params.checkerDateTimeFrom = reqThirdDate;
-                }
-                ;
+                    scope.searchCriteria.audit[2] = params.checkerDateTimeFrom;
+                } else
+                    scope.searchCriteria.audit[2] = null;
+
+                if (scope.formData.status) {
+                    params.processingResult = scope.formData.status;
+                    scope.searchCriteria.audit[3] = params.processingResult;
+                } else
+                    scope.searchCriteria.audit[3] = null;
+
+                if (scope.formData.action) {
+                    params.actionName = scope.formData.action;
+                    scope.searchCriteria.audit[4] = params.actionName;
+                } else
+                    scope.searchCriteria.audit[4] = null;
+
+                if (scope.formData.resourceId) {
+                    params.resourceId = scope.formData.resourceId;
+                    scope.searchCriteria.audit[5] = params.resourceId;
+                } else
+                    scope.searchCriteria.audit[5] = null;
+
+                if (scope.date.second) {
+                    params.makerDateTimeTo = reqSecondDate;
+                    scope.searchCriteria.audit[6] = params.makerDateTimeTo;
+                } else
+                    scope.searchCriteria.audit[6] = null;
 
                 if (scope.date.fourth) {
                     params.checkerDateTimeTo = reqFourthDate;
-                }
-                ;
-                resourceFactory.auditResource.search(params,function(data) {
+                    scope.searchCriteria.audit[7] = params.checkerDateTimeTo;
+                } else
+                    scope.searchCriteria.audit[7] = null;
+
+                if (scope.formData.entity) {
+                    params.entityName = scope.formData.entity;
+                    scope.searchCriteria.audit[8] = params.entityName;
+                } else
+                    scope.searchCriteria.audit[8] = null;
+
+                if (scope.formData.checkedBy) {
+                    params.checkerId = scope.formData.checkedBy;
+                    scope.searchCriteria.audit[9] = params.checkerId;
+                } else
+                    scope.searchCriteria.audit[9] = null;
+
+                scope.saveSC();
+                resourceFactory.auditResource.search(params, function (data) {
                     scope.searchData.pageItems = data.pageItems;
 
-                    if (scope.searchData.pageItems == '') {
+                    if (scope.searchData.pageItems == '')
                         scope.flag = false;
-                    } else {
+                    else
                         scope.flag = true;
-                    }
+
                     scope.row = [];
                     scope.csvData = [];
-                    if (scope.userTypeahead) {
-                        scope.formData.user = '';
-                        scope.userTypeahead = false;
-                        scope.user = '';
-                    }
+
                     scope.row = ['Id', 'Resource Id', 'Status', 'Office', 'Made on', 'Maker', 'Checked on', 'Checker', 'Entity', 'Action', 'Client'];
                     scope.csvData.push(scope.row);
                     for (var i in scope.searchData.pageItems) {
-                        scope.row = [scope.searchData.pageItems[i].id, scope.searchData.pageItems[i].resourceId, scope.searchData.pageItems[i].processingResult, scope.searchData.pageItems[i].officeName,dateFilter(scope.searchData.pageItems[i].madeOnDate, 'yyyy-MM-dd'), scope.searchData.pageItems[i].maker, dateFilter(scope.searchData.pageItems[i].checkedOnDate, 'yyyy-MM-dd hh:mm:ss'), scope.searchData.pageItems[i].checker, scope.searchData.pageItems[i].entityName, scope.searchData.pageItems[i].actionName, scope.searchData.pageItems[i].clientName];
+                        scope.row = [scope.searchData.pageItems[i].id, scope.searchData.pageItems[i].resourceId, scope.searchData.pageItems[i].processingResult, scope.searchData.pageItems[i].officeName, dateFilter(scope.searchData.pageItems[i].madeOnDate, 'yyyy-MM-dd'), scope.searchData.pageItems[i].maker, dateFilter(scope.searchData.pageItems[i].checkedOnDate, 'yyyy-MM-dd hh:mm:ss'), scope.searchData.pageItems[i].checker, scope.searchData.pageItems[i].entityName, scope.searchData.pageItems[i].actionName, scope.searchData.pageItems[i].clientName];
                         scope.csvData.push(scope.row);
                     }
                     callback(data);
                 });
             };
 
-            scope.audit = paginatorService.paginate(fetchFunction, 14);
-
+            scope.searchAudit = function () {
+                scope.audit = paginatorService.paginate(fetchFunction, 14);
+            };
+            scope.searchAudit();
         }
     });
-    mifosX.ng.application.controller('AuditController', ['$scope', 'ResourceFactory','PaginatorService', 'dateFilter', '$location', mifosX.controllers.AuditController]).run(function ($log) {
+    mifosX.ng.application.controller('AuditController', ['$scope', 'ResourceFactory', 'PaginatorService', 'dateFilter', '$location', mifosX.controllers.AuditController]).run(function ($log) {
         $log.info("AuditController initialized");
     });
 }(mifosX.controllers || {}));
-
-

--- a/app/scripts/controllers/user/UserSettingController.js
+++ b/app/scripts/controllers/user/UserSettingController.js
@@ -1,8 +1,8 @@
 (function (module) {
     mifosX.controllers = _.extend(module, {
         UserSettingController: function (scope, translate, localStorageService, tmhDynamicLocale) {
-            if (localStorageService.get('Language')) {
-                var temp = localStorageService.get('Language');
+            if (localStorageService.getFromLocalStorage('Language')) {
+                var temp = localStorageService.getFromLocalStorage('Language');
                 for (var i in mifosX.models.Langs) {
                     if (mifosX.models.Langs[i].code == temp.code) {
                         scope.optlang = mifosX.models.Langs[i];
@@ -27,8 +27,8 @@
                 'MM-dd-yy'
             ];
             
-            if (localStorageService.get('dateformat')) {
-                var temp = localStorageService.get('dateformat');
+            if (localStorageService.getFromLocalStorage('dateformat')) {
+                var temp = localStorageService.getFromLocalStorage('dateformat');
 
                 for (var i = 0; i < scope.dates.length; i++) {
                     if (scope.dates[i] == temp) {
@@ -43,14 +43,14 @@
             scope.$watch(function () {
                 return scope.dateformat;
             }, function () {
-                localStorageService.add('dateformat', scope.dateformat);
+                localStorageService.addToLocalStorage('dateformat', scope.dateformat);
                 scope.df = scope.dateformat;
             });
             
             scope.langs = mifosX.models.Langs;
             scope.changeLang = function (lang) {
                 translate.uses(lang.code);
-                localStorageService.add('Language', scope.optlang);
+                localStorageService.addToLocalStorage('Language', scope.optlang);
                 tmhDynamicLocale.set(lang.code);
             };
 

--- a/app/scripts/filters/DateFormat.js
+++ b/app/scripts/filters/DateFormat.js
@@ -4,7 +4,7 @@
             return function (input) {
                 if (input) {
                     var tDate = new Date(input);
-                    return dateFilter(tDate, localStorageService.get('dateformat'));
+                    return dateFilter(tDate, localStorageService.getFromLocalStorage('dateformat'));
                 }
                 return '';
             }

--- a/app/scripts/modules/localstorage.js
+++ b/app/scripts/modules/localstorage.js
@@ -1,52 +1,52 @@
-(function () {
-    /* Start angularLocalStorage */
+angular.module('LocalStorageModule', [])
+    // You should set a prefix to avoid overwriting any local storage variables from the rest of your app
+    // e.g. angularLocalStorage.constant('prefix', 'youAppName');
+    .value('prefix', 'ls')
+    // Cookie options (usually in case of fallback)
+    // expiry = Number of days before cookies expire // 0 = Does not expire
+    // path = The web path the cookie represents
+    .constant('cookie', {
+        expiry: 30,
+        path: '/'
+    })
 
-    var angularLocalStorage = angular.module('LocalStorageModule', []);
+    .constant('notify', {
+        setItem: true,
+        removeItem: false
+    })
 
-// You should set a prefix to avoid overwriting any local storage variables from the rest of your app
-// e.g. angularLocalStorage.constant('prefix', 'youAppName');
-    angularLocalStorage.value('prefix', 'ls');
-// Cookie options (usually in case of fallback)
-// expiry = Number of days before cookies expire // 0 = Does not expire
-// path = The web path the cookie represents
-    angularLocalStorage.constant('cookie', { expiry: 30, path: '/'});
-    angularLocalStorage.constant('notify', { setItem: true, removeItem: false});
+    .service('localStorageService', ['$rootScope', 'prefix', 'cookie', 'notify', function ($rootScope, prefix, cookie, notify) {
+        // If there is a prefix set in the config lets use that with an appended period for readability
+        //var prefix = angularLocalStorage.constant;
+        if (prefix.substr(-1) !== '.')
+            prefix = !!prefix ? prefix + '.' : '';
 
-    angularLocalStorage.service('localStorageService', [
-        '$rootScope',
-        'prefix',
-        'cookie',
-        'notify',
-        function ($rootScope, prefix, cookie, notify) {
-
-            // If there is a prefix set in the config lets use that with an appended period for readability
-            //var prefix = angularLocalStorage.constant;
-            if (prefix.substr(-1) !== '.') {
-                prefix = !!prefix ? prefix + '.' : '';
-            }
-
+        return {
             // Checks the browser to see if local storage is supported
-            var browserSupportsLocalStorage = function () {
+            browserSupportsLocalStorage: function () {
                 try {
                     return ('localStorage' in window && window['localStorage'] !== null);
                 } catch (e) {
                     $rootScope.$broadcast('LocalStorageModule.notification.error', e.message);
                     return false;
                 }
-            };
+            },
 
             // Directly adds a value to local storage
             // If local storage is not available in the browser use cookies
-            // Example use: localStorageService.add('library','angular');
-            var addToLocalStorage = function (key, value) {
-
+            // Example use: localStorageService.addToLocalStorage('library','angular');
+            addToLocalStorage: function (key, value) {
                 // If this browser does not support local storage use cookies
-                if (!browserSupportsLocalStorage()) {
+                if (!this.browserSupportsLocalStorage()) {
                     $rootScope.$broadcast('LocalStorageModule.notification.warning', 'LOCAL_STORAGE_NOT_SUPPORTED');
                     if (notify.setItem) {
-                        $rootScope.$broadcast('LocalStorageModule.notification.setitem', {key: key, newvalue: value, storageType: 'cookie'});
+                        $rootScope.$broadcast('LocalStorageModule.notification.setitem', {
+                            key: key,
+                            newvalue: value,
+                            storageType: 'cookie'
+                        });
                     }
-                    return addToCookies(key, value);
+                    return this.addToCookies(key, value);
                 }
 
                 // Let's convert undefined values to null to get the value consistent
@@ -55,26 +55,29 @@
                 }
 
                 try {
-                    if (angular.isObject(value) || angular.isArray(value)) {
+                    if (angular.isObject(value) || angular.isArray(value))
                         value = angular.toJson(value);
-                    }
                     localStorage.setItem(prefix + key, value);
                     if (notify.setItem) {
-                        $rootScope.$broadcast('LocalStorageModule.notification.setitem', {key: key, newvalue: value, storageType: 'localStorage'});
+                        $rootScope.$broadcast('LocalStorageModule.notification.setitem', {
+                            key: key,
+                            newvalue: value,
+                            storageType: 'localStorage'
+                        });
                     }
                 } catch (e) {
                     $rootScope.$broadcast('LocalStorageModule.notification.error', e.message);
-                    return addToCookies(key, value);
+                    return this.addToCookies(key, value);
                 }
                 return true;
-            };
+            },
 
             // Directly get a value from local storage
-            // Example use: localStorageService.get('library'); // returns 'angular'
-            var getFromLocalStorage = function (key) {
-                if (!browserSupportsLocalStorage()) {
+            // Example use: localStorageService.getFromLocalStorage('library'); returns 'angular'
+            getFromLocalStorage: function (key) {
+                if (!this.browserSupportsLocalStorage()) {
                     $rootScope.$broadcast('LocalStorageModule.notification.warning', 'LOCAL_STORAGE_NOT_SUPPORTED');
-                    return getFromCookies(key);
+                    return this.getFromCookies(key);
                 }
 
                 var item = localStorage.getItem(prefix + key);
@@ -86,36 +89,41 @@
                     return angular.fromJson(item);
                 }
                 return item;
-            };
+            },
 
             // Remove an item from local storage
-            // Example use: localStorageService.remove('library'); // removes the key/value pair of library='angular'
-            var removeFromLocalStorage = function (key) {
-                if (!browserSupportsLocalStorage()) {
+            // Example use: localStorageService.removeFromLocalStorage('library'); removes the key/value pair of library='angular'
+            removeFromLocalStorage: function (key) {
+                if (!this.browserSupportsLocalStorage()) {
                     $rootScope.$broadcast('LocalStorageModule.notification.warning', 'LOCAL_STORAGE_NOT_SUPPORTED');
                     if (notify.removeItem) {
-                        $rootScope.$broadcast('LocalStorageModule.notification.removeitem', {key: key, storageType: 'cookie'});
+                        $rootScope.$broadcast('LocalStorageModule.notification.removeitem', {
+                            key: key,
+                            storageType: 'cookie'
+                        });
                     }
-                    return removeFromCookies(key);
+                    return this.removeFromCookies(key);
                 }
 
                 try {
                     localStorage.removeItem(prefix + key);
                     if (notify.removeItem) {
-                        $rootScope.$broadcast('LocalStorageModule.notification.removeitem', {key: key, storageType: 'localStorage'});
+                        $rootScope.$broadcast('LocalStorageModule.notification.removeitem', {
+                            key: key,
+                            storageType: 'localStorage'
+                        });
                     }
                 } catch (e) {
                     $rootScope.$broadcast('LocalStorageModule.notification.error', e.message);
-                    return removeFromCookies(key);
+                    return this.removeFromCookies(key);
                 }
                 return true;
-            };
+            },
 
             // Return array of keys for local storage
-            // Example use: var keys = localStorageService.keys()
-            var getKeysForLocalStorage = function () {
-
-                if (!browserSupportsLocalStorage()) {
+            // Example use: var keys = localStorageService.getKeysForLocalStorage()
+            getKeysFromLocalStorage: function () {
+                if (!this.browserSupportsLocalStorage()) {
                     $rootScope.$broadcast('LocalStorageModule.notification.warning', 'LOCAL_STORAGE_NOT_SUPPORTED');
                     return false;
                 }
@@ -134,16 +142,15 @@
                     }
                 }
                 return keys;
-            };
+            },
 
             // Remove all data for this app from local storage
-            // Example use: localStorageService.clearAll();
+            // Example use: localStorageService.clearAllFromLocalStorage();
             // Should be used mostly for development purposes
-            var clearAllFromLocalStorage = function () {
-
-                if (!browserSupportsLocalStorage()) {
+            clearAllFromLocalStorage: function () {
+                if (!this.browserSupportsLocalStorage()) {
                     $rootScope.$broadcast('LocalStorageModule.notification.warning', 'LOCAL_STORAGE_NOT_SUPPORTED');
-                    return clearAllFromCookies();
+                    return this.clearAllFromCookies();
                 }
 
                 var prefixLength = prefix.length;
@@ -152,7 +159,7 @@
                     // Only remove items that are for this app
                     if (key.substr(0, prefixLength) === prefix) {
                         try {
-                            removeFromLocalStorage(key.substr(prefixLength));
+                            this.removeFromLocalStorage(key.substr(prefixLength));
                         } catch (e) {
                             $rootScope.$broadcast('LocalStorageModule.notification.error', e.message);
                             return clearAllFromCookies();
@@ -160,30 +167,28 @@
                     }
                 }
                 return true;
-            };
+            },
 
             // Checks the browser to see if cookies are supported
-            var browserSupportsCookies = function () {
+            browserSupportsCookies: function () {
                 try {
                     return navigator.cookieEnabled ||
                         ("cookie" in document && (document.cookie.length > 0 ||
-                            (document.cookie = "test").indexOf.call(document.cookie, "test") > -1));
+                        (document.cookie = "test").indexOf.call(document.cookie, "test") > -1));
                 } catch (e) {
                     $rootScope.$broadcast('LocalStorageModule.notification.error', e.message);
                     return false;
                 }
-            };
+            },
 
             // Directly adds a value to cookies
             // Typically used as a fallback is local storage is not available in the browser
-            // Example use: localStorageService.cookie.add('library','angular');
-            var addToCookies = function (key, value) {
-
-                if (typeof value == "undefined") {
+            // Example use: localStorageService.addToCookies('library','angular');
+            addToCookies: function (key, value) {
+                if (typeof value == "undefined")
                     return false;
-                }
 
-                if (!browserSupportsCookies()) {
+                if (!this.browserSupportsCookies()) {
                     $rootScope.$broadcast('LocalStorageModule.notification.error', 'COOKIES_NOT_SUPPORTED');
                     return false;
                 }
@@ -194,26 +199,24 @@
                         // Mark that the cookie has expired one day ago
                         expiryDate.setTime(expiryDate.getTime() + (-1 * 24 * 60 * 60 * 1000));
                         expiry = "; expires=" + expiryDate.toGMTString();
-
                         value = '';
                     } else if (cookie.expiry !== 0) {
                         expiryDate.setTime(expiryDate.getTime() + (cookie.expiry * 24 * 60 * 60 * 1000));
                         expiry = "; expires=" + expiryDate.toGMTString();
                     }
-                    if (!!key) {
+                    if (!!key)
                         document.cookie = prefix + key + "=" + encodeURIComponent(value) + expiry + "; path=" + cookie.path;
-                    }
                 } catch (e) {
                     $rootScope.$broadcast('LocalStorageModule.notification.error', e.message);
                     return false;
                 }
                 return true;
-            };
+            },
 
             // Directly get a value from a cookie
-            // Example use: localStorageService.cookie.get('library'); // returns 'angular'
-            var getFromCookies = function (key) {
-                if (!browserSupportsCookies()) {
+            // Example use: localStorageService.getFromCookies('library'); returns 'angular'
+            getFromCookies: function (key) {
+                if (!this.browserSupportsCookies()) {
                     $rootScope.$broadcast('LocalStorageModule.notification.error', 'COOKIES_NOT_SUPPORTED');
                     return false;
                 }
@@ -221,50 +224,29 @@
                 var cookies = document.cookie.split(';');
                 for (var i = 0; i < cookies.length; i++) {
                     var thisCookie = cookies[i];
-                    while (thisCookie.charAt(0) == ' ') {
+                    while (thisCookie.charAt(0) == ' ')
                         thisCookie = thisCookie.substring(1, thisCookie.length);
-                    }
-                    if (thisCookie.indexOf(prefix + key + '=') === 0) {
+                    if (thisCookie.indexOf(prefix + key + '=') === 0)
                         return decodeURIComponent(thisCookie.substring(prefix.length + key.length + 1, thisCookie.length));
-                    }
                 }
                 return null;
-            };
+            },
 
-            var removeFromCookies = function (key) {
-                addToCookies(key, null);
-            };
+            removeFromCookies: function (key) {
+                this.addToCookies(key, null);
+            },
 
-            var clearAllFromCookies = function () {
+            clearAllFromCookies: function () {
                 var thisCookie = null, thisKey = null;
                 var prefixLength = prefix.length;
                 var cookies = document.cookie.split(';');
                 for (var i = 0; i < cookies.length; i++) {
                     thisCookie = cookies[i];
-                    while (thisCookie.charAt(0) == ' ') {
+                    while (thisCookie.charAt(0) == ' ')
                         thisCookie = thisCookie.substring(1, thisCookie.length);
-                    }
                     key = thisCookie.substring(prefixLength, thisCookie.indexOf('='));
-                    removeFromCookies(key);
+                    this.removeFromCookies(key);
                 }
-            };
-
-            return {
-                isSupported: browserSupportsLocalStorage,
-                set: addToLocalStorage,
-                add: addToLocalStorage, //DEPRECATED
-                get: getFromLocalStorage,
-                keys: getKeysForLocalStorage,
-                remove: removeFromLocalStorage,
-                clearAll: clearAllFromLocalStorage,
-                cookie: {
-                    set: addToCookies,
-                    add: addToCookies, //DEPRECATED
-                    get: getFromCookies,
-                    remove: removeFromCookies,
-                    clearAll: clearAllFromCookies
-                }
-            };
-
-        }]);
-}).call(this);
+            }
+        }
+    }]);

--- a/app/scripts/services/AuthenticationService.js
+++ b/app/scripts/services/AuthenticationService.js
@@ -3,7 +3,7 @@
         AuthenticationService: function (scope, httpService, localStorageService) {
             var onSuccess = function (data) {
                 scope.$broadcast("UserAuthenticationSuccessEvent", data);
-                localStorageService.add('userData', data);
+                localStorageService.addToLocalStorage('userData', data);
             };
 
             var onFailure = function (data) {

--- a/app/views/accounting/search_transaction.html
+++ b/app/views/accounting/search_transaction.html
@@ -6,7 +6,7 @@
 
 	<div class="form-inline paddedtop paddedbottom10" ng-show="isCollapsed">
         <div class="form-group">
-        	<select chosen="glAccounts" ng-autofocus="true" class="form-control" ng-model="formData.glAccount" ng-options="glAccount as glAccount.name + ' ' + glAccount.glCode for glAccount in glAccounts" value="{{office.id}}">
+        	<select chosen="glAccounts" ng-autofocus="true" class="form-control" ng-model="formData.glAccount" ng-options="glAccount.id as glAccount.name + ' ' + glAccount.glCode for glAccount in glAccounts" value="{{glAccount.id}}">
                 <option class="displaynone" value="">{{'label.input.selectaccountnameorcode' | translate}}</option>
             </select>
         </div>
@@ -22,7 +22,7 @@
 		</div>
         <div class="form-group">
             <input class="form-control" type="text" datepicker-pop="dd MMMM yyyy" ng-model="date.first" is-open="opened" min="minDate" max="'2020-06-22'" placeholder="{{ 'label.input.fromdate' | translate }}" style="width: 155px;"/>
-		</div>        
+		</div>
 		<div class="form-group">
             <input class="form-control" type="text" datepicker-pop="dd MMMM yyyy" ng-model="date.second" is-open="opened1" min="minDate" max="'2020-06-22'" placeholder="{{ 'label.input.todate' | translate }}" style="width: 155px;"/>
         </div>
@@ -31,7 +31,7 @@
 		</div>
 		<div class="clear"></div>
 		-OR-
-		<br> 
+		<br>
 		<div class="form-group">
             <input ng-model="formData.transactionId" type="text"
             	placeholder="{{'label.input.searchbytransaction' | translate}}" class="form-control"/>

--- a/app/views/system/audit.html
+++ b/app/views/system/audit.html
@@ -3,70 +3,53 @@
         <li><a href="#/system">{{'label.anchor.system' | translate}}</a></li>
         <li class="active">{{'label.anchor.audit' | translate}}</li>
     </ul>
+
     <div class="form-inline" data-ng-show="isCollapsed">
         <div class="form-group">
 			<span class="input-append grpinputicons">
-				<input ng-autofocus="true" autocomplete="off" typeahead-on-select="viewUser($item)"
-                       placeholder="{{'label.input.searchbyuser' | translate}}" type="text" ng-model="user"
-                       class="form-control"
-                       typeahead="users.username as users.username for users in template.appUsers | filter:$viewValue | limitTo:8"/>
-				<span><button ng-click="isCollapsed = !isCollapsed" class="btn btn-default"><i
-                        class="icon-chevron-down"></i></button></span>
-				<span><button ng-click="search()" class="btn btn-primary control" has-permission='READ_AUDIT'><i
-                        class="icon-search icon-white"></i></button></span>
+				<input ng-autofocus="true" autocomplete="off" typeahead-on-select="viewUser($item)" placeholder="{{'label.input.searchbyuser' | translate}}" type="text" ng-model="formData.user" class="form-control" typeahead="users.username as users.username for users in template.appUsers | filter:$viewValue | limitTo:8"/>
+				<span><button ng-click="isCollapsed = !isCollapsed" class="btn btn-default"><i class="icon-chevron-down"></i></button></span>
+				<span><button ng-click="searchAudit()" class="btn btn-primary control" has-permission='READ_AUDIT'><i class="icon-search icon-white"></i></button></span>
 			</span>
         </div>
     </div>
+
     <div data-ng-hide="isCollapsed">
         <div class="form-inline">
-            <input ng-autofocus="true" autocomplete="off" typeahead-on-select="viewUser($item)"
-                   placeholder="{{'label.input.searchbyuser' | translate}}" type="text" ng-model="user"
-                   class="form-control"
-                   typeahead="users.username as users.username for users in template.appUsers | filter:$viewValue | limitTo:8"/>
-            <input type="text" sort placeholder="{{'label.input.fromdate' | translate}}"
-                   datepicker-pop="dd MMMM yyyy" ng-model="date.first" is-open="opened" min="minDate"
-                   max="'2020-06-22'" class="form-control"/>
-            <input type="text" sort placeholder="{{'label.input.checkedfrom' | translate}}"
-                   datepicker-pop="dd MMMM yyyy" ng-model="date.third" is-open="opened2" min="minDate"
-                   max="'2020-06-22'" class="form-control"/>
-            <select value="{{status.id}}" ng-model="formData.status" class="form-control width170px"
-                    data-ng-options="status.id as status.processingResult | translate for status in template.processingResults">
+            <input ng-autofocus="true" autocomplete="off" typeahead-on-select="viewUser($item)" placeholder="{{'label.input.searchbyuser' | translate}}" type="text" ng-model="formData.user" class="form-control" typeahead="users.username as users.username for users in template.appUsers | filter:$viewValue | limitTo:8"/>
+            <input type="text" sort placeholder="{{'label.input.fromdate' | translate}}" datepicker-pop="dd MMMM yyyy" ng-model="date.first" is-open="opened" min="minDate" max="'2020-06-22'" class="form-control"/>
+            <input type="text" sort placeholder="{{'label.input.checkedfrom' | translate}}" datepicker-pop="dd MMMM yyyy" ng-model="date.third" is-open="opened2" min="minDate" max="'2020-06-22'" class="form-control"/>
+            <select value="{{status.id}}" ng-model="formData.status" class="form-control width170px" data-ng-options="status.id as status.processingResult | translate for status in template.processingResults">
                 <option value="">--{{'label.selectstatus' | translate}}--</option>
             </select>
             <select ng-model="formData.action" class="form-control width170px">
                 <option value="">--{{'label.selectaction' | translate}}--</option>
-                <option selected="selected" value="ALL">{{'label.all' | translate}}</option>
+                <option selected="selected" value="">{{'label.all' | translate}}</option>
                 <option ng-repeat="action in template.actionNames" value="{{action}}">{{action}}</option>
             </select>
         </div>
 
         <div class="form-inline">
-            <input type="text" placeholder="{{'label.input.resourceid' | translate}}"
-                   ng-model="formData.resourceId" class="form-control">
-            <input type="text" sort placeholder="{{'label.input.todate' | translate}}" datepicker-pop="dd MMMM yyyy"
-                   ng-model="date.second" is-open="opened1" min="minDate" max="'2020-06-22'" class="form-control"/>
-            <input type="text" sort placeholder="{{'label.input.checkedto' | translate}}"
-                   datepicker-pop="dd MMMM yyyy" ng-model="date.fourth" is-open="opened3" min="minDate"
-                   max="'2020-06-22'" class="form-control"/>
+            <input type="text" placeholder="{{'label.input.resourceid' | translate}}" ng-model="formData.resourceId" class="form-control">
+            <input type="text" sort placeholder="{{'label.input.todate' | translate}}" datepicker-pop="dd MMMM yyyy" ng-model="date.second" is-open="opened1" min="minDate" max="'2020-06-22'" class="form-control"/>
+            <input type="text" sort placeholder="{{'label.input.checkedto' | translate}}" datepicker-pop="dd MMMM yyyy" ng-model="date.fourth" is-open="opened3" min="minDate" max="'2020-06-22'" class="form-control"/>
             <select ng-model="formData.entity" class="form-control width170px">
                 <option value="">--{{'label.selectentity' | translate}}--</option>
-                <option selected="selected" value="ALL">{{'label.all' | translate}}</option>
+                <option selected="selected" value="">{{'label.all' | translate}}</option>
                 <option ng-repeat="entity in template.entityNames" value="{{entity}}">{{entity}}</option>
             </select>
             <select ng-model="formData.checkedBy" class="form-control width170px">
                 <option value="">--{{'label.selectchecker' | translate}}--</option>
-                <option selected="selected" value="ALL">{{'label.all' | translate}}</option>
+                <option selected="selected" value="">{{'label.all' | translate}}</option>
                 <option ng-repeat="user in template.appUsers" value="{{user.id}}">{{user.username}}</option>
             </select>
-            <span><a ng-click="search()" class="btn btn-primary control" has-permission='READ_AUDIT'><i
-                    class="icon-search icon-white"></i>{{'label.button.advancesearch' | translate}}</a></span>
+            <span><a ng-click="searchAudit()" class="btn btn-primary control" has-permission='READ_AUDIT'><i class="icon-search icon-white"></i>{{'label.button.advancesearch' | translate}}</a></span>
         </div>
     </div>
+
     <div ng-show="displayResults">
         <div data-ng-show="flag" class="pull-right">
-            <button type="button" class="btn btn-primary" ng-csv="csvData"><i class="icon-file icon-white"></i>{{'label.button.exportcsv'
-                | translate }}
-            </button>
+            <button type="button" class="btn btn-primary" ng-csv="csvData"><i class="icon-file icon-white"></i>{{'label.button.exportcsv' | translate }}</button>
         </div>
         <div scroll data-ng-show="flag">
             <table class="table table-bordered width1200px" data-anchor>
@@ -85,8 +68,7 @@
                 </tr>
                 </thead>
                 <tbody>
-                <tr class="highlight-row pointer" data-ng-click="routeTo(data.id)"
-                    ng-repeat="data in searchData.pageItems">
+                <tr class="highlight-row pointer" data-ng-click="routeTo(data.id)" ng-repeat="data in searchData.pageItems">
                     <td>{{data.id}}</td>
                     <td>{{data.resourceId}}</td>
                     <td>{{data.processingResult | translate}}</td>
@@ -100,20 +82,17 @@
                 </tr>
                 </tbody>
             </table>
-
         </div>
 
         <ul class="pager">
-            <li class="previous"><a id="prev" ng-click="audit.previous()" href=""
-                                    ng-disabled="!audit.hasPrevious()">&larr; {{'label.button.previous' | translate}}</a>
+            <li class="previous">
+                <a id="prev" ng-click="audit.previous()" href="" ng-disabled="!audit.hasPrevious()">&larr; {{'label.button.previous' | translate}}</a>
             </li>
-            <li class="next"><a id="next" ng-click="audit.next()" href="" ng-disabled="!audit.hasNext()">{{'label.button.next'
-                | translate}} &rarr;</a></li>
+            <li class="next">
+                <a id="next" ng-click="audit.next()" href="" ng-disabled="!audit.hasNext()">{{'label.button.next' | translate}} &rarr;</a>
+            </li>
         </ul>
 
-        <h3 data-ng-show="!flag" class="auditnodata"><strong>{{ 'label.nodata' |
-            translate }}</strong></h3>
-
+        <h3 data-ng-show="!flag" class="auditnodata"><strong>{{ 'label.nodata' | translate }}</strong></h3>
     </div>
-
 </div>

--- a/test/spec/controllers/MainControllerSpec.js
+++ b/test/spec/controllers/MainControllerSpec.js
@@ -15,7 +15,7 @@ describe("MainController", function () {
 
         this.translate = jasmine.createSpyObj("translate", ["uses"]);
         this.rootScope = jasmine.createSpy();
-        this.localStorageService = jasmine.createSpyObj("localStorageService", ["get", "add"]);
+        this.localStorageService = jasmine.createSpyObj("localStorageService", ["addToLocalStorage", "getFromLocalStorage"]);
         this.idle = jasmine.createSpyObj("$idle", ['watch', 'unwatch']);
         this.tmhDynamicLocale = jasmine.createSpyObj("tmhDynamicLocale", ["set"]);
 

--- a/test/spec/controllers/user/UserSettingControllerSpec.js
+++ b/test/spec/controllers/user/UserSettingControllerSpec.js
@@ -6,8 +6,8 @@ describe("UserSettingController", function () {
             uses: jasmine.createSpy("translate.uses()")
         };
         this.localStorageService = {
-            get: jasmine.createSpy("localStorageService.get()").andReturn({"name": "English", "code": "en"}),
-            add: jasmine.createSpy("localStorageService.add()")
+            getFromLocalStorage: jasmine.createSpy("localStorageService.getFromLocalStorage()").andReturn({"name": "English", "code": "en"}),
+            addToLocalStorage: jasmine.createSpy("localStorageService.addToLocalStorage()")
         };
         this.tmhDynamicLocale = jasmine.createSpyObj("tmhDynamicLocale", ["set"]);
         this.controller = new mifosX.controllers.UserSettingController(this.scope, this.translate, this.localStorageService, this.tmhDynamicLocale);
@@ -26,7 +26,7 @@ describe("UserSettingController", function () {
         this.scope.optlang = this.scope.langs[1];
         this.scope.changeLang(this.scope.langs[1]);
         expect(this.translate.uses).toHaveBeenCalledWith('fr');
-        expect(this.localStorageService.add).toHaveBeenCalledWith('Language', {"name": "Français", "code": "fr"});
+        expect(this.localStorageService.addToLocalStorage).toHaveBeenCalledWith('Language', {"name": "Français", "code": "fr"});
     });
 
 });

--- a/test/spec/services/AuthenticationServiceSpec.js
+++ b/test/spec/services/AuthenticationServiceSpec.js
@@ -3,7 +3,7 @@ describe("AuthenticationService", function () {
     beforeEach(function () {
         callbacks = {};
         scope = jasmine.createSpyObj("$rootScope", ['$broadcast']);
-        localStorageService = jasmine.createSpyObj('localStorageService', ['add']);
+        localStorageService = jasmine.createSpyObj('localStorageService', ['addToLocalStorage']);
 
         httpService = jasmine.createSpyObj("httpService", ['post', 'success', 'error']);
         httpService.post.andReturn(httpService);


### PR DESCRIPTION
Part of GCI Task:
http://www.google-melange.com/gci/task/view/google/gci2014/5794719778996224

Details:
- Search settings in Accounting -> Search Journal Entries and System -> Audit will now be saved to local storage and will be loaded into the fields when the pages are loaded.
- Due to my task, I needed to use local storage. I looked at the localStorageService and thought it needed to be formatted/changed, but don't worry, all files associated with and use local storage have been changed.
- In Audit, I noticed an error would be thrown if the search fields contained :
  = If user contained letters instead of an id - user will now automatically changed to an id upon search.
  = If action, entity, or check were selected to "ALL" - ALL is not an id, so an error is thrown (All selection is now null to search properly)
- Audit no longer uses hard coded dates
