### PR TITLE
MifosX-1785 - Add tolltips and Glossary entires for Global Configuration and Saving Account Labels

### DIFF
--- a/app/scripts/controllers/configurations/GlobalConfigurationController.js
+++ b/app/scripts/controllers/configurations/GlobalConfigurationController.js
@@ -1,12 +1,13 @@
 (function (module) {
     mifosX.controllers = _.extend(module, {
-        GlobalConfigurationController: function (scope, resourceFactory, location, route) {
+        GlobalConfigurationController: function (scope,$rootScope, resourceFactory, location, route) {
             scope.configs = [];
             resourceFactory.configurationResource.get(function (data) {
                 for (var i in data.globalConfiguration) {
                     data.globalConfiguration[i].showEditvalue = true;
                     scope.configs.push(data.globalConfiguration[i])
                 }
+				
                 resourceFactory.cacheResource.get(function (data) {
                     for (var i in data) {
                         if (data[i].cacheType && data[i].cacheType.id == 2) {
@@ -19,6 +20,7 @@
                     }
                 });
             });
+			
 
             scope.enable = function (id, name) {
                 if (name == 'Is Cache Enabled') {
@@ -50,10 +52,81 @@
                     });
                 }
             };
+			
+			scope.setDescript = function()
+			{
+				if(tooltiplang == 'en')
+					{
+						var descriptions = ['Determine if the maker-checker system will be used.','Determines if file and image uploads will be handled by alternative Amazon S3 cloud storage.',
+						'If enabled, reschedules repayments which fall on a non-working day to configured repayment rescheduling rule.','Determine if repayments that occur on holidays will be rescheduled.',
+						'Determine if transactions will be permitted on holidays.','Determine if transactions will be permitted on non-working days, such as weekends.',
+						'Determines whether the Code Value Name or the Code Value ID will be stored in the generated data table.','Defined in terms of days. Defines how many days overdue before an overdue penalty will be charged.',
+						'Determine if passwords expire and whether or not users will be required to reset their passwords after a certain number of days.','Determines whether Moratorium functionality is permitted. If enabled, Moratorium functionality is allowed; if disabled, Moratorium functionality is not allow.',
+						'Recommended to be changed only once during start of production. When set as false(default), interest will be posted on the first date of next period. If set as true, interest will be posted on last date of current period. There is no difference in the interest amount posted.',
+						'This should be set at the database level before any savings interest is posted. Allowed values 1 - 12 (January - December). Interest posting periods are evaluated based on this configuration.',
+						'Determines if caching is enabled in the platform to improve performance.'];
+						
+							for(var i in scope.configs)
+							{
+								scope.configs[i].description = descriptions[i];
+							}
+												
+					}//default - English
+					else if(tooltiplang == 'fr')
+					{
+						//add here translated descriptions in array like above
+						for(var i in scope.configs)
+						{
+							scope.configs[i].description = 'Need a French translation'; // here get description for configs[i] from array and set it, like above
+						}
+					}//French
+					else if(tooltiplang == 'es')
+					{
+						//add here translated descriptions in array like above
+						for(var i in scope.configs)
+						{
+							scope.configs[i].description = 'Need a Spanish translation'; // here get description for configs[i] from array and set it, like above
+						}
+					}//Espanyol
+					else if(tooltiplang == 'pt')
+					{
+						//add here translated descriptions in array like above
+						for(var i in scope.configs)
+						{
+							scope.configs[i].description = 'Need a Portugese translation'; // here get description for configs[i] from array and set it, like above
+						}
+					}//Portugese
+					else if(tooltiplang == 'zh_CN')
+					{	
+						//add here translated descriptions in array like above
+						for(var i in scope.configs)
+						{
+							scope.configs[i].description = 'Need a Chinese translation'; // // here get description for configs[i] from array and set it, like above
+						}
+					}//Chinese
+					else if(tooltiplang == 'hi')
+					{
+						//add here translated descriptions in array like above
+						for(var i in scope.configs)
+						{
+							scope.configs[i].description = 'Need a Hindi translation'; // // here get description for configs[i] from array and set it, like above
+						}
+					}//Hindi
+					else if(tooltiplang == 'ka')
+					{
+						//add here translated descriptions in array like above
+						for(var i in scope.configs)
+						{
+							scope.configs[i].description = 'Need a Georgian translation'; // here get description for configs[i] from array and set it, like above
+						}
+					}//Georgian
+					
+			
+			};
 
         }
     });
-    mifosX.ng.application.controller('GlobalConfigurationController', ['$scope', 'ResourceFactory', '$location', '$route', mifosX.controllers.GlobalConfigurationController]).run(function ($log) {
+    mifosX.ng.application.controller('GlobalConfigurationController', ['$scope','$rootScope', 'ResourceFactory', '$location', '$route', mifosX.controllers.GlobalConfigurationController]).run(function ($log) {
         $log.info("GlobalConfigurationController initialized");
     });
 }(mifosX.controllers || {}));

--- a/app/scripts/controllers/main/MainController.js
+++ b/app/scripts/controllers/main/MainController.js
@@ -2,6 +2,8 @@
     mifosX.controllers = _.extend(module, {
         MainController: function (scope, location, sessionManager, translate, $rootScope, localStorageService, keyboardManager, $idle, tmhDynamicLocale) {
 
+			$rootScope.tooltiplang = 'en'; // default language of tooltips
+			
             //hides loader
             scope.domReady = true;
             scope.activity = {};
@@ -128,11 +130,13 @@
                     if (mifosX.models.Langs[i].code == temp.code) {
                         scope.optlang = mifosX.models.Langs[i];
                         tmhDynamicLocale.set(mifosX.models.Langs[i].code);
+						tooltiplang = scope.optlang.code;
                     }
                 }
             } else {
                 scope.optlang = scope.langs[0];
                 tmhDynamicLocale.set(scope.langs[0].code);
+				tooltiplang = scope.optlang.code;
             }
             translate.uses(scope.optlang.code);
 
@@ -237,11 +241,12 @@
                 localStorageService.addToLocalStorage('Language', lang);
                 tmhDynamicLocale.set(lang.code);
                 scope.optlang = lang;
+				tooltiplang = lang.code;
             };
 			scope.helpf = function()
 			{
 				// first, create addresses array
-			    var addresses = ["https://mifosforge.jira.com/wiki/display/docs/User+Setup","https://mifosforge.jira.com/wiki/display/docs/Organization",
+			var addresses = ["https://mifosforge.jira.com/wiki/display/docs/User+Setup","https://mifosforge.jira.com/wiki/display/docs/Organization",
 				"https://mifosforge.jira.com/wiki/display/docs/System",	"https://mifosforge.jira.com/wiki/dosearchsite.action?queryString=products&startIndex=0&where=docs",
 				"https://mifosforge.jira.com/wiki/pages/viewpage.action?pageId=67141762","https://mifosforge.jira.com/wiki/dosearchsite.action?queryString=report&startIndex=0&where=docs",
 				"https://mifosforge.jira.com/wiki/dosearchsite.action?queryString=accounting&startIndex=0&where=docs",	"https://mifosforge.jira.com/wiki/display/docs/Manage+Clients",
@@ -264,7 +269,7 @@
 				"https://mifosforge.jira.com/wiki/pages/viewpage.action?pageId=67895308","https://mifosforge.jira.com/wiki/display/docs/Accruals"]; 
 			// array is huge, but working good
 			// create second array with address models
-		    	var addrmodels = ['/users/','/organization','/system','/products','/templates',	'',	'/accounting',
+			var addrmodels = ['/users/','/organization','/system','/products','/templates',	'',	'/accounting',
 								'/clients',	'/groups','/centers','','/offices',	'/holidays','/employees','/managefunds/',
 								'/bulkloan','/currconfig','/standinginstructions/history','/datatables','/codes','/admin/roles',
 								'/admin/viewmctasks','/hooks','/audit',	'/reports','/jobs','/global','/accountnumberpreferences','/loanproducts',

--- a/app/scripts/controllers/user/UserSettingController.js
+++ b/app/scripts/controllers/user/UserSettingController.js
@@ -1,6 +1,6 @@
 (function (module) {
     mifosX.controllers = _.extend(module, {
-        UserSettingController: function (scope, translate, localStorageService, tmhDynamicLocale) {
+        UserSettingController: function (scope,$rootScope, translate, localStorageService, tmhDynamicLocale) {
             if (localStorageService.getFromLocalStorage('Language')) {
                 var temp = localStorageService.getFromLocalStorage('Language');
                 for (var i in mifosX.models.Langs) {
@@ -15,6 +15,7 @@
             }
             
             translate.uses(scope.optlang.code);
+			
             
             scope.dates = [
                 'dd MMMM yyyy',
@@ -52,12 +53,13 @@
                 translate.uses(lang.code);
                 localStorageService.addToLocalStorage('Language', scope.optlang);
                 tmhDynamicLocale.set(lang.code);
+				tooltiplang = lang.code;								
             };
 
         }
     });
 
-    mifosX.ng.application.controller('UserSettingController', ['$scope', '$translate', 'localStorageService', 'tmhDynamicLocale', mifosX.controllers.UserSettingController]).run(function ($log) {
+    mifosX.ng.application.controller('UserSettingController', ['$scope','$rootScope', '$translate', 'localStorageService', 'tmhDynamicLocale', mifosX.controllers.UserSettingController]).run(function ($log) {
         $log.info("UserSettingController initialized");
     });
 }(mifosX.controllers || {}));

--- a/app/views/administration/global.html
+++ b/app/views/administration/global.html
@@ -3,7 +3,8 @@
         <li class="active">{{'label.anchor.globalconfigurations' | translate}}</li>
     </ul>
 </div>
-<div ng-controller="GlobalConfigurationController">
+<div ng-controller="GlobalConfigurationController" >
+	<td> {{setDescript()}}</td>
     <input ng-model="filterText" type="text" class="form-control"
            placeholder="{{'label.input.filterbyname' | translate}}">
     <table class="table">
@@ -22,12 +23,15 @@
 			{{config.name | translate}}
 			&nbsp; &nbsp; &nbsp;<i class="icon-question-sign icon-white" tooltip="{{config.description}}"></i>
 			</td>
-            <td>{{config.enabled}}</td>
             <td>
-                <button type="button" class="btn btn-success flag" data-ng-hide="config.enabled"
-                        data-ng-click="enable(config.id, config.name)" has-permission='UPDATE_CONFIGURATION'><i class="icon-flag-alt"></i></button>
-                <button type="button" class="btn btn-danger flag" data-ng-show="config.enabled"
-                        data-ng-click="disable(config.id, config.name)" has-permission='UPDATE_CONFIGURATION'><i class="icon-remove"></i></button>
+                <i class="icon-ok-sign icon-green" data-ng-show="config.enabled"></i>
+                <i class="icon-remove-sign icon-red" data-ng-hide="config.enabled"></i>
+            </td>
+            <td>
+                <button type="button" class="btn btn-primary" data-ng-hide="config.enabled"
+                        data-ng-click="enable(config.id, config.name)" has-permission='UPDATE_CONFIGURATION'>{{"label.button.enable" | translate}}</i></button>
+                <button type="button" class="btn btn-danger" data-ng-show="config.enabled"
+                        data-ng-click="disable(config.id, config.name)" has-permission='UPDATE_CONFIGURATION'>{{"label.button.disable" | translate}}</i></button>
                 
             </td>
             <td>{{config.value}}</td>


### PR DESCRIPTION
How it works?
Global Configuration:
First, we get a code of actual used language and on it we base our conditional statement for setting tooltip description.
Descriptions are stored in local array.
For each language translation is needed - currently I have only English descriptions(default) . OR we could use only English descriptions, but I preferred prepare the ground for translations - it's better for non-English/poor-English speaking users from countries which languages we're supporting.
Create Saving Product: there tooltips were already implemented, but in HTML-side ( {{ label.something.description | translate }} ) but not every language have translation.
Again video - it describe working of this better than words.
https://www.youtube.com/watch?v=3bF7VB3GrDA&list=UUwxv9pbKAQghaAjS-N23s1w
