### PR TITLE
README.md: Use "npm config set prefix ~"

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Travis
 
 1. Note: Ensure you have ```npm``` installed - goto http://nodejs.org/download/ to download installer for your OS.  On Ubuntu Linux you can use 'sudo apt-get install npm nodejs-legacy' (nodejs-legacy is required to avoid the ""/usr/bin/env: node: No such file or directory" problem).
 
+1. Tip: If you are using Ubuntu/Linux, then doing ```npm config set prefix ~``` prevents you from having to run npm as root.
+
 1. Clone this repository to your local filesystem (default branch is 'develop')
 
 1. To download the dependencies, and be able to build, first install bower & grunt


### PR DESCRIPTION
Hi guys, merge this for me, please? (Give me commit access to community-app, just like I already have for back-end, and proven to use responsibly, so that I don't have to bother you - I promise I will behave..)

as per http://stackoverflow.com/questions/19352976/npm-modules-wont-install-globally-without-sudo