### PR TITLE
center/group meeting fix

### DIFF
--- a/app/scripts/controllers/groups/AttachMeetingController.js
+++ b/app/scripts/controllers/groups/AttachMeetingController.js
@@ -30,7 +30,7 @@
                     scope.periodValue = "day(s)"
                 }
                 if (period == 2) {
-                    scope.repeatsEveryOptions = ["1", "2", "3"];
+                    scope.repeatsEveryOptions = ["1", "2", "3","4","5"];
                     scope.formData.repeatsOnDay = '1';
                     scope.periodValue = "week(s)";
                     scope.repeatsOnOptions = [

--- a/app/scripts/controllers/groups/EditMeetingController.js
+++ b/app/scripts/controllers/groups/EditMeetingController.js
@@ -47,7 +47,7 @@
                     scope.periodValue = "day(s)"
                 }
                 if (period == 2) {
-                    scope.repeatsEveryOptions = ["1", "2", "3"];
+                    scope.repeatsEveryOptions = ["1", "2", "3","4","5"];
                     scope.formData.repeatsOnDay = '1';
                     scope.periodValue = "week(s)";
                     scope.repeatsOnOptions = [
@@ -84,10 +84,10 @@
                 resourceFactory.attachMeetingResource.update({groupOrCenter: routeParams.entityType,
                     groupOrCenterId: routeParams.groupOrCenterId, templateSource: routeParams.calendarId}, this.formData, function (data) {
                     var destURI = "";
-                    if (routeParams.entityType == "GROUPS") {
+                    if (routeParams.entityType == "groups") {
                         destURI = "viewgroup/" + routeParams.groupOrCenterId;
                     }
-                    else if (routeParams.entityType == "CENTERS") {
+                    else if (routeParams.entityType == "centers") {
                         destURI = "viewcenter/" + routeParams.groupOrCenterId;
                     }
                     location.path(destURI);


### PR DESCRIPTION
senario1 :-  attaching or editing the meeting for any center/group

if we select the meetings as "weekly" in Repeats every drop down was only till 3, but chaitanya wanted a meeting to be set for 4 weeks. hence added 4 and 5 to that drop down.

issue2:- when ever we edit and submit the meeting dates it used to go to the start screen of mifos instead of view group/center screen,this also fixed.