### PR TITLE
 STRETCHY-REPORT

### DIFF
--- a/app/scripts/controllers/system/EditReportController.js
+++ b/app/scripts/controllers/system/EditReportController.js
@@ -47,6 +47,7 @@
             scope.submit = function () {
                 if (scope.reportdetail.coreReport === true) {
                     this.formData.reportParameters = scope.temp;
+                    this.formData.useReport = scope.reportdetail.useReport;
                 } else {
                     scope.temp = deepCopy(scope.reportdetail.reportParameters);
                     scope.reportdetail.reportParameters = scope.temp;


### PR DESCRIPTION
If a stretchy report's query is modified and submitted, it does not save the modified query.It shows the previously defined query. 
There is a platform level check that for core reports - modifications are not allowed (other than the "user report" field).

