### PR TITLE
MIFOSX-2327

### DIFF
--- a/app/scripts/controllers/groups/TransferClientsController.js
+++ b/app/scripts/controllers/groups/TransferClientsController.js
@@ -9,7 +9,7 @@
             scope.destinationGroup = "";
 
             resourceFactory.groupResource.get({groupId: routeParams.id, associations: 'clientMembers'}, function (data) {
-                scope.data = data;
+                scope.group = data;
                 scope.allMembers = data.clientMembers;
             });
 


### PR DESCRIPTION
Cancel button under transfer clients in groups would not send the user back to the group page, would only bring up a blank page. Button now pulls up original group page. 