### PR TITLE
Added the loading effect to the login callback method.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -37,6 +37,9 @@
             <br/><br/>
             <div ng-hide="resetPassword">
     	    <form class="form-inline pull-right" role="form">
+            <div data-ng-show="load" style="position: absolute; top: 50%; left: 48%; z-index: 1000;">
+                <img src="images/cubic_loader.gif" class="img-responsive">
+            </div>
     		<label class="error" data-ng-show="authenticationFailed"><strong>{{ authenticationErrorMessage | translate }}</strong></label>
     		<div class="form-group">
     		    <input ng-autofocus="true" type="text" data-ng-model="loginCredentials.username" placeholder="{{ 'label.input.username' | translate }}" class="input-sm form-control" required id="uid">

--- a/app/scripts/controllers/main/LoginFormController.js
+++ b/app/scripts/controllers/main/LoginFormController.js
@@ -4,8 +4,10 @@
             scope.loginCredentials = {};
             scope.passwordDetails = {};
             scope.authenticationFailed = false;
+            scope.load = false;
 
             scope.login = function () {
+                scope.load = true;
                 authenticationService.authenticateWithUsernamePassword(scope.loginCredentials);
                // delete scope.loginCredentials.password;
             };
@@ -15,15 +17,18 @@
                 scope.authenticationFailed = true;
                 if(status != 401) {
                     scope.authenticationErrorMessage = 'error.connection.failed';
+                    scope.load = false;
                 } else {
                    scope.authenticationErrorMessage = 'error.login.failed';
+                   scope.load = false;
                 }
             });
 
             scope.$on("UserAuthenticationSuccessEvent", function (event, data) {
+                scope.load = false;
                 timer = $timeout(function(){
                     delete scope.loginCredentials.password;
-                },2000)
+                },2000);
              });
 
             /*This logic is no longer required as enter button is binded with text field for submit.

--- a/app/scripts/services/ResourceFactoryProvider.js
+++ b/app/scripts/services/ResourceFactoryProvider.js
@@ -4,6 +4,7 @@
             var baseUrl = "" , apiVer = "/fineract-provider/api/v1", tenantIdentifier = "";
             this.setBaseUrl = function (url) {
                 baseUrl = url;
+                console.log(baseUrl);
             };
 
             this.setTenantIdenetifier = function (tenant) {

--- a/app/views/login.html
+++ b/app/views/login.html
@@ -10,5 +10,6 @@
     <div data-ng-show="authenticationFailed">
         <p>{{authenticationErrorMessage | translate}}</p>
     </div>
+    
 </div>
 


### PR DESCRIPTION
Actually when you enter your credential (mifos/password) on the home page of the community-ap and hit the login button every thing just remain static while there is the login process happening behind. I consider this as not user friendly I propose to attach a loading effect to the promise of the login process. This is just for more user experience. 