### PR TITLE
Fix for MIFOSX-2617

### DIFF
--- a/app/views/navigation/offices.html
+++ b/app/views/navigation/offices.html
@@ -151,6 +151,18 @@
             <td>{{staff.officeName}}</td>
         </tr>
     </table>
+    <div class="row">
+        <div class="col-sm-5 col-md-5">
+            <ng-summary title="# {{ 'label.heading.center' | translate }}">
+                <h1 class="center">{{centers.length}}</h1>
+            </ng-summary>
+        </div>
+        <div class="col-sm-5 col-md-5">
+            <ng-summary title="# {{ 'label.heading.center' | translate }}">
+                <h1 class="center">{{centers.length}}</h1>
+            </ng-summary>
+        </div>
+    </div>
 </div>
 <div ng-show="center">
     <br/>


### PR DESCRIPTION
Display #Centers for each staff. Displayed it in the same format as #Staff is. It needs https://github.com/openMF/community-app/pull/1492 to be merged first to show up properly