### PR TITLE
updated the online demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Travis
 
 ## Online Demo
 
-<a target="_blank" href="https://demo.openmf.org/beta">Access the online demo version here</a>
+<a target="_blank" href="https://demo.openmf.org">Access the online demo version here</a>
 
 
 ## Building from source


### PR DESCRIPTION
the previous link was https://demo.openmf.org/beta which is not working. so i changed it to https://demo.openmf.org