### PR TITLE
Made errors more descriptive

### DIFF
--- a/app/scripts/controllers/reports/RunReportsController.js
+++ b/app/scripts/controllers/reports/RunReportsController.js
@@ -2,7 +2,6 @@
     mifosX.controllers = _.extend(module, {
 
         RunReportsController: function (scope, routeParams, resourceFactory, location, dateFilter, http, API_VERSION, $rootScope, $sce) {
-
             scope.isCollapsed = false; //displays options div on startup
             scope.hideTable = true; //hides the results div on startup
             scope.hidePentahoReport = true; //hides the results div on startup
@@ -158,7 +157,6 @@
                 scope.errorDetails = [];
                 for (var i in scope.reqFields) {
                     var paramDetails = scope.reqFields[i];
-
                     switch (paramDetails.displayType) {
                         case "select":
                             var selectedVal = scope.formData[paramDetails.inputName];
@@ -213,7 +211,6 @@
                             }
                             break;
                         default:
-                            console.log(paramDetails.displayType);
                             var errorObj = new Object();
                             errorObj.field = paramDetails.inputName;
                             errorObj.code = 'error.message.report.parameter.invalid';
@@ -377,7 +374,6 @@
                                     x.values.push(inner);
                                 }
                                 scope.barData.push(x);
-                                console.log(scope.barData);
                             });
                             break;
                         default:

--- a/app/scripts/controllers/system/EditCodeController.js
+++ b/app/scripts/controllers/system/EditCodeController.js
@@ -4,10 +4,9 @@
             scope.codevalues = [];
             scope.newcodevalues = [];
             scope.newEle = {};
+            scope.errorDetails = [];
             scope.codevalueerror = false;
             scope.newEle.isActive = true;
-
-
             resourceFactory.codeResources.get({codeId: routeParams.id}, function (data) {
                 scope.code = data;
                 scope.codeId = data.id;
@@ -20,7 +19,7 @@
 
             scope.addCv = function () {
                 if (scope.newEle != undefined && scope.newEle.hasOwnProperty('name')) {
-                    scope.codevalueerror = true;
+                    //scope.codevalueerror = true;
                     resourceFactory.codeValueResource.save({codeId: routeParams.id}, this.newEle, function (data) {
                         scope.stat = false;
                         location.path('/viewcode/' + routeParams.id);
@@ -28,6 +27,13 @@
                 } else if (!scope.newEle.name) {
                     scope.codevalueerror = true;
                     scope.labelerror = "codevalueerror";
+                    scope.errorDetails = [];
+                    var errorObj = new Object();
+                    errorObj.args = {
+                        params: []
+                    };
+                    errorObj.args.params.push({value:'label.input.codevalue'});
+                    scope.errorDetails.push(errorObj);
                 }
 
             };
@@ -44,3 +50,5 @@
         $log.info("EditCodeController initialized");
     });
 }(mifosX.controllers || {}));
+
+

--- a/app/scripts/directives/ApiValidationDirective.js
+++ b/app/scripts/directives/ApiValidationDirective.js
@@ -7,13 +7,12 @@
                 link: function (scope, elm, attr, ctrl) {
                     var template = '<div class="error" ng-repeat="errorArray in errorDetails" ng-show="errorStatus || errorDetails">' +
                         '<label>' +
-                        '{{' + "'label.error'" + ' | translate}}' +
+                        '{{' + 'errorArray.args.params[0].value'    +' | translate}}' + ' field is required' +
                         '</label>' +
                         '<label ng-show="errorStatus">{{errorStatus}}</label>' +
                         '<label ng-hide="errorStatus" ng-repeat="error in errorArray">' +
                         '{{error.code | translate:error.args}}' +
                         '</label></div>';
-
                     elm.html('').append($compile(template)(scope));
                 }
             };

--- a/app/views/administration/system.html
+++ b/app/views/administration/system.html
@@ -35,7 +35,6 @@
             <a class="list-group-item" href="#/entitytoentitymapping" has-permission='READ_PERMISSION'>
                 <h4 class="list-group-item-heading"><i class="icon-road icon-large"></i>&nbsp;&nbsp;{{'label.anchor.entitytoentitymapping'
                     | translate}}</h4>
-
                 <p class="list-group-item-text">{{'label.definemappings' | translate}}</p>
             </a>
         </div>

--- a/app/views/system/viewcode.html
+++ b/app/views/system/viewcode.html
@@ -73,7 +73,7 @@
                     <td>
                         <span data-ng-hide="codevalue.edit">{{codevalue.name}}</span>
                         <input data-ng-show="codevalue.edit" name="codevalue" ng-model="formData[codevalue.id].name"
-                               type="text" class="form-control"/>
+                               type="text" class="form-control" required/>
                     </td>
                     <td>
                         <span data-ng-hide="codevalue.edit">{{codevalue.description}}</span>


### PR DESCRIPTION
Hi, I have again filed this PR because @rajuan suggested to file the PR in a single commit and I have checked this issue on all the reports, it is working fine.

This **PR** is for this [issue](https://mifosforge.jira.com/browse/MIFOSX-2555?jql=labels%20%3D%20AngularJS) on **JIRA**.There were 3 enhancements in this issue

1. To generate first error of this issue follow the next given steps (Log in the account -> Reports -> Loans -> Select one of the loan item -> Run Report). This is how it will look 
<img width="1159" alt="screen shot 2016-03-03 at 11 03 01 pm 1" src="https://cloud.githubusercontent.com/assets/8019601/13645189/c6e8aa06-e64f-11e5-9ba4-1b7ac698bd15.png">

* After my work the warnings are now more descriptive as given below 
![corrected](https://cloud.githubusercontent.com/assets/8019601/13645217/eae3b504-e64f-11e5-9a2b-a6ad7f5a044c.png)


2 To generate second error of this issue follow the next given steps (Log in the account -> Admin -> System -> ManageCodes -> Select any code name -> Add Code Values -> Click on Add Button)

* By clicking on the add button nothing happens but some warning must be generated.
* After my work on this part of the issue, when no field is filled the warning is shown like
![corrected](https://cloud.githubusercontent.com/assets/8019601/13645457/1c4179f0-e651-11e5-9957-8d004abe940b.png)

3 To generate the third error of this issue follow the next given steps (Log in the account -> Admin -> Products -> Loan Products -> Create Loan Product)

* The description on JIRA says that when principal field is left blank, no warning is genrated but it is already generating when principal field is left blank so I don't think any work is required here :smile:  
