### PR TITLE
Fix MIFOSX-2639

### DIFF
--- a/app/scripts/controllers/client/CreateClientController.js
+++ b/app/scripts/controllers/client/CreateClientController.js
@@ -109,6 +109,14 @@
                     this.formData.dateOfBirth = dateFilter(scope.first.dateOfBirth, scope.df);
                 }
 
+                if (this.formData.legalFormId == scope.clientPersonId || this.formData.legalFormId == null) {
+                    delete this.formData.fullname;
+                } else {
+                    delete this.formData.firstname;
+                    delete this.formData.middlename;
+                    delete this.formData.lastname;
+                }
+
                 if(scope.first.incorpValidityTillDate) {
                     this.formData.clientNonPersonDetails.locale = scope.optlang.code;
                     this.formData.clientNonPersonDetails.dateFormat = scope.df;


### PR DESCRIPTION
This PR fixes MIFOSX-2639.

Whenever the user goes to create a client and fills in data (such as first name, last name) for a particular legal form such as PERSON and then midway switches to another legal form such as ENTITY, it causes a conflict with the API since the JSON payload now contains both fullname, lastname and firstname while the allowed conditions are only firstname,lastname OR fullname. This code deletes the particular json keys and values depending on the scope in which the form is being submitted.