### PR TITLE
MIFOSX-2555:Made error more descriptive

### DIFF
--- a/app/global-translations/locale-en.json
+++ b/app/global-translations/locale-en.json
@@ -2207,6 +2207,7 @@
     "validation.msg.user.password.exceeds.max.length": "Password cannot be over 50 characters long.",
     "validation.msg.user.repeatPassword.not.equal.to.password": "Password and repeat password do not match.",
     "error.msg.user.duplicate.username": "User with username `{{params[0].value}}` already exists.",
+    "validation.msg.user.password.does.not.match.regexp":"Password must contain atleast one uppercase letter",
 
     "#------": "------------",
 


### PR DESCRIPTION
There was Error issue while creating a user 
When any one enters plain text password it didn't showed the actual error 
![error](https://cloud.githubusercontent.com/assets/9936881/14505257/043ab0b0-01d6-11e6-9c66-c1d4ce8c5a85.PNG)

After my work it's able to show the exact error

![error1](https://cloud.githubusercontent.com/assets/9936881/14505290/23ec60b6-01d6-11e6-8118-8f0dbae413fc.PNG)

Thanks
