### PR TITLE
Fix for MIFOSX-[2782]

### DIFF
--- a/app/views/organization/createpaymenttype.html
+++ b/app/views/organization/createpaymenttype.html
@@ -39,11 +39,12 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="control-label col-sm-2" >{{'label.input.position' | translate}}</label>
+                    <label class="control-label col-sm-2" >{{'label.input.position' | translate}}<span
+                            class="required">*</span></label>
 
                     <div class="col-sm-3">
                         <input name="position" ng-model="formData.position"
-                                  type="text" class="form-control"/>
+                                  type="number" class="form-control"/>
                     </div>
                 </div>
                 <div class="col-md-offset-2 paddedleft">


### PR DESCRIPTION
MIFOSX-2782:
In ADMIN>>ORGANISATION>>PAYMENT TYPE>>ADD PAYMENT TYPE, the position field was not marked mandatory(*) and the input type was "text".

Marked the position field mandatory(*) and changed the input type to number.