### PR TITLE
Fixed Error messages in Datatable entry

### DIFF
--- a/app/views/system/makedatatableentry.html
+++ b/app/views/system/makedatatableentry.html
@@ -1,11 +1,5 @@
 <form class="form-horizontal well" ng-controller="MakeDataTableEntryController" ng-submit="submit()">
-    <div class="error" ng-show="errorStatus || errorDetails">
-        <label>{{"label.error" | translate}}</label>
-        <label ng-show="errorStatus">{{errorStatus}}</label>
-        <label ng-hide="errorStatus" ng-repeat="error in errorDetails">
-            {{error.code | translate:error.args}}-{{error.field}}
-        </label>
-    </div>
+<api-validate></api-validate>
     <fieldset>
         <legend>{{ 'label.heading.makedatatableentry' | translate }}</legend>
         <h3>{{ 'label.heading.datatablename' | translate }}-<strong>{{tableName}}</strong></h3>


### PR DESCRIPTION
@nazeer1100126 
Issue:
Proper error messages were not displaying in the make-datatable entry form.
Fix:
added api-validate directive which would display proper messages.