### PR TITLE
Make link on Mifos start up page plain text (MIFOSX-2809)

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -245,9 +245,13 @@
                         <div class="whitebg" ng-view></div>
                     </div>
                     <!-- Footer -->
-					<footer>
-						<p align="center"> <a href="https://mifosforge.jira.com/browse/MIFOSX/component/11710/?selectedTab=com.atlassian.jira.jira-projects-plugin:component-changelog-panel" target="_blank"> {{'label.relVersion' | translate}} {{version}} | {{'label.relDate' | translate}} {{releasedate}} </a> </p>
-					</footer>
+                    <footer>
+                        <p align="center">
+                            <a href="https://github.com/openMF/incubator-fineract/blob/master/MIFOS-CHANGELOG.md" target="_blank">
+                                {{'label.relVersion' | translate}} {{version}} | {{'label.relDate' | translate}} {{releasedate}}
+                            </a>
+                        </p>
+                    </footer>
                     <hr>
                 </div> <!-- /row-fluid -->
             </div><!-- /blockui-->


### PR DESCRIPTION
* Fixes showing of a dead link to the user

Removed the anchor tag, which contained a dead link. Instead, made it plain text. Also reformatted the code a little bit.
Fixes #1736