### PR TITLE
Fix #2052, Disbursement page not showing all fields

### DIFF
--- a/app/views/loans/loanaccountactions.html
+++ b/app/views/loans/loanaccountactions.html
@@ -92,7 +92,7 @@
         </table>
     </div>
 </div>
-<div ng-hide="disbursementDetails">
+<div ng-show="disbursementDetails">
     <div class="form-group" ng-show="showApprovalAmount">
         <label class="control-label col-sm-2" for="approvedAmount">{{ 'label.input.transactionamount' |
             translate}}<span class="required">*</span></label>


### PR DESCRIPTION
Fix #2052, Disbursement and Disburse to savings not showing required fields. 