### PR TITLE
Reskin: Fix #2047 - Add buttons are disabled when terms vary checkbox is unchecked in Cre…

### DIFF
--- a/app/scripts/controllers/product/CreateLoanProductController.js
+++ b/app/scripts/controllers/product/CreateLoanProductController.js
@@ -50,7 +50,7 @@
                 }
                 scope.formData.currencyCode = scope.product.currencyOptions[0].code;
                 scope.formData.includeInBorrowerCycle = 'false';
-                scope.formData.useBorrowerCycle = 'false';
+                scope.formData.useBorrowerCycle = false;
                 scope.formData.digitsAfterDecimal = '2';
                 scope.formData.inMultiplesOf = '0';
                 scope.formData.repaymentFrequencyType = scope.product.repaymentFrequencyType.id;
@@ -221,7 +221,7 @@
 			if ((multiDisburseLoan != true) && item.chargeTimeType.id == 12) {
 				return false;
 			}
-			if (item.currency.code != currencyCode) { 
+			if (item.currency.code != currencyCode) {
 				return false;
 			}
 			return true;


### PR DESCRIPTION
I disabled the three rows which contains a label and a add button when the 'Terms Vary Based on Loan Cycle' is unchecked. When the checkbox is checked then  disabled rows are enabled,

Please view the changes made and tell me whether it is working or not.

Thank You :)