### PR TITLE
Reskin: Fix #2011 - 'Charge Overview' is not displayed when the client has no 'Client Charge'

### DIFF
--- a/app/scripts/controllers/client/ViewClientController.js
+++ b/app/scripts/controllers/client/ViewClientController.js
@@ -407,6 +407,10 @@
 
             resourceFactory.clientChargesResource.getCharges({clientId: routeParams.id, pendingPayment:true}, function (data) {
                 scope.charges = data.pageItems;
+                if(scope.charges.length == 0)
+                  scope.formData.upcomingcharges = "";
+                else
+                  scope.formData.upcomingcharges = "true";
             });
 
             scope.isClosed = function (loanaccount) {

--- a/app/views/clients/viewclient.html
+++ b/app/views/clients/viewclient.html
@@ -213,18 +213,18 @@
 								<api-validate></api-validate>
 								<div class="pull-right" data-ng-show="charges">
 										<span>
-											<button type="button" class="btn-primary btn btn-sm" data-ng-click="routeToChargeOverview()">{{
+											<button type="button" class="btn-primary btn btn-sm" data-ng-click="routeToChargeOverview()" ng-show="formData.upcomingcharges">{{
 												'label.button.chargesoverview' | translate }}
 											</button>
 										</span>
 								</div>
 								<div  data-ng-show="charges">
 									<div class="span gray-head">
-											<span class="boldlabel">
+											<span class="boldlabel" ng-show="formData.upcomingcharges">
 												  <strong>{{ 'label.heading.upcomingcharges' | translate }}</strong>
 											</span>
 									</div>
-									<table class="table table-condensed">
+									<table class="table table-condensed" ng-show="formData.upcomingcharges">
 										<tr class="graybg">
 											<th>{{'label.heading.name' | translate}}</th>
 											<th>{{'label.heading.dueasof' | translate}}</th>


### PR DESCRIPTION

![screenshot 17](https://cloud.githubusercontent.com/assets/10477029/23747356/5a05e9d4-04e5-11e7-916f-c182795db1e9.png)
When the client charge is empty the Charge Overview is not displayed.

Please view the changes made and tell me whether it is working or not.

Thank You :)