### PR TITLE
Reskin: Fix #2069 - Removed the fields beside Terms in loan application

### DIFF
--- a/app/views/loans/newloanaccount.html
+++ b/app/views/loans/newloanaccount.html
@@ -165,7 +165,7 @@
                                     </td>
                                     <td ng-hide="response.uiDisplayConfigurations.loanAccount.isHiddenField.repaymentEvery == true"><label>{{ 'label.input.repaidevery' | translate }}&nbsp;<span class="required">*</span></label></td>
                                     <td class="paddedbottom10 width500px" ng-hide="response.uiDisplayConfigurations.loanAccount.isHiddenField.repaymentEvery == true">
-                                    
+
                                         <input id="repaymentEvery" class="form-control" type="text" name="repaidevery"
                                             ng-model="formData.repaymentEvery" ng-disabled="!loanaccountinfo.product.allowAttributeOverrides.repaymentEvery" required late-Validate/>
                                         <select id="repaymentFrequencyType" class="form-control" ng-model="formData.repaymentFrequencyType"
@@ -180,10 +180,10 @@
                                                 ng-options="repaymentFrequencyDayOfWeekType.id as repaymentFrequencyDayOfWeekType.value for repaymentFrequencyDayOfWeekType in loanaccountinfo.repaymentFrequencyDaysOfWeekTypeOptions"
                                                 ng-show="formData.repaymentFrequencyType == 2"
                                                 value="{{repaymentFrequencyDayOfWeekType.id}}"/>&nbsp;
-                                            
+
                                         <form-validate valattributeform="newloanaccountform" valattribute="repaidevery"/>
                                     </td>
-                                    
+
                                 </tr>
                                 <tr>
                                     <td ng-hide="response.uiDisplayConfigurations.loanAccount.isHiddenField.repaymentsStartingFromDate == true">
@@ -200,30 +200,6 @@
                                         <input id="interestChargedFromDate" type="text" datepicker-pop="dd MMMM yyyy" ng-model="date.third"
                                             is-open="opened2" min="minDate" max="'2020-06-22'" class="form-control"/>
                                     </td>
-                                </tr>
-
-                                                                            <input id="repaymentEvery" class="form-control" type="text" name="repaidevery"
-                                                                                ng-model="formData.repaymentEvery" ng-disabled="!loanaccountinfo.product.allowAttributeOverrides.repaymentEvery" required late-Validate/>
-                                                                            <select id="repaymentFrequencyType" class="form-control" ng-model="formData.repaymentFrequencyType"
-                                                                                    ng-options="repaymentFrequencyType.id as repaymentFrequencyType.value for repaymentFrequencyType in loanaccountinfo.termFrequencyTypeOptions"
-                                                                                    ng-disabled="!loanaccountinfo.product.allowAttributeOverrides.repaymentEvery"
-                                                                                    value="{{repaymentFrequencyType.id}}"/>&nbsp;<span ng-show="formData.repaymentFrequencyType == 2">on</span>
-                                                                            <select id="repaymentFrequencyNthDayType" class="form-control" ng-model="formData.repaymentFrequencyNthDayType"
-                                                                                    ng-options="repaymentFrequencyNthDayType.id as repaymentFrequencyNthDayType.value for repaymentFrequencyNthDayType in loanaccountinfo.repaymentFrequencyNthDayTypeOptions"
-                                                                                    ng-show="formData.repaymentFrequencyType == 2"
-                                                                                    value="{{repaymentFrequencyNthDayType.id}}"/>&nbsp;
-                                                                            <select id="repaymentFrequencyDayOfWeekType" class="form-control" ng-model="formData.repaymentFrequencyDayOfWeekType"
-                                                                                    ng-options="repaymentFrequencyDayOfWeekType.id as repaymentFrequencyDayOfWeekType.value for repaymentFrequencyDayOfWeekType in loanaccountinfo.repaymentFrequencyDaysOfWeekTypeOptions"
-                                                                                    ng-show="formData.repaymentFrequencyType == 2"
-                                                                                    value="{{repaymentFrequencyDayOfWeekType.id}}"/>&nbsp;
-
-                                                                            <form-validate valattributeform="newloanaccountform" valattribute="repaidevery"/>
-                                                                        </td>
-
-                                                                    </tr>
-
-
-
                                 </tr>
                                 <tr>
                                     <td ng-hide="response.uiDisplayConfigurations.loanAccount.isHiddenField.inArrearsTolerance == true"><label>{{ 'label.input.arearstolerance' | translate }}</label></td>


### PR DESCRIPTION
The "Terms" field and "Repaid every" field in loan application have the same function so I removed the fields beside Terms in loan application.

Please view the changes made and tell me whether it is working or not.

Thank You :)


![screenshot 19](https://cloud.githubusercontent.com/assets/10477029/23823197/6ecd914c-0683-11e7-9f4b-9d15219facd4.png)
