### PR TITLE
Reskin: #2035: fixed alignment of edit share account page

### DIFF
--- a/app/views/shares/editshareaccount.html
+++ b/app/views/shares/editshareaccount.html
@@ -10,9 +10,9 @@
             <h4>{{ 'label.heading.sharesapplication' | translate }}</h4>
         </div>
         <br>
-        <form name="newsavingccountform" novalidate="" class="form-inline"                      rc-submit="submit()">
-        <fieldset>
-        <table class="width100">
+        <form name="newsavingccountform" novalidate="" class="form-inline" rc-submit="submit()">
+            <fieldset>
+            <table class="table width100">
             <tr>
                 <td class="width14">
                     <label>{{ 'label.input.product' | translate }}<span class="required">*</span>:&nbsp;</label>
@@ -48,7 +48,7 @@
         <label><strong>{{ 'label.heading.terms' | translate }}</strong></label>
 
         <div>
-        <table class="width100">
+        <table class="table width100">
             <tr>
                 <td class="width14"><label class="control-label">{{ 'label.heading.currency' | translate }}</label>
                 </td>


### PR DESCRIPTION
fixed alignment of edit share account page.
before -
![alt text](https://cloud.githubusercontent.com/assets/23022667/23644482/8776cbf4-032d-11e7-8bd9-0bba6e7e280c.png "before")

after-
![alt text](https://github.com/anu-007/assets/blob/master/Screenshot%20from%202017-03-19%2021-08-11.png?raw=true"after")
