### PR TITLE
Fix for Fineract-389

### DIFF
--- a/app/views/accounting/accounting_coa.html
+++ b/app/views/accounting/accounting_coa.html
@@ -27,7 +27,7 @@
             </tr>
             </thead>
             <tbody>
-            <tr class="pointer-main" ng-repeat="coadata in coadatas | orderBy:'type.value' | SearchFilter:filterText">
+            <tr class="pointer-main" ng-repeat="coadata in coadatas | orderBy:['type.value','glCode']| SearchFilter:filterText">
                 <td class="pointer" data-ng-click="routeTo(coadata.id)">{{coadata.name}}</td>
                 <td class="pointer" data-ng-click="routeTo(coadata.id)">{{coadata.glCode}}</td>
                 <td class="pointer" data-ng-click="routeTo(coadata.id)">{{coadata.type.value | translate}}</td>


### PR DESCRIPTION
Added secondary ordering parameter for coa as glCode. Now the accounts in chart accounts are ordered according to the account type and the accounts of same type will be ordered in the order of their GLCode. 