### PR TITLE
Fix issue 2175 - Should be "prepay loan " instead of "repayment"

### DIFF
--- a/app/scripts/controllers/loanAccount/LoanAccountActionsController.js
+++ b/app/scripts/controllers/loanAccount/LoanAccountActionsController.js
@@ -143,7 +143,7 @@
                     scope.isTransaction = true;
                     scope.showAmountField = true;
                     scope.taskPermissionName = 'REPAYMENT_LOAN';
-                    scope.action = 'repayment';
+                    scope.action = 'prepayloan';
                     break;
                 case "waiveinterest":
                     scope.modelName = 'transactionDate';


### PR DESCRIPTION
Before the fix of issue #2175 

![prepaybefore](https://cloud.githubusercontent.com/assets/8160209/25333325/6fbc1466-28f2-11e7-99ee-cc9fe321ea89.png)

After the fix

![prepayafter](https://cloud.githubusercontent.com/assets/8160209/25333338/74de67c8-28f2-11e7-98d3-2280033af3ba.png)



