### PR TITLE
Fix #2208 - Reskin: Edit Center page is not showing proper labels

### DIFF
--- a/app/views/centers/editcenter.html
+++ b/app/views/centers/editcenter.html
@@ -1,7 +1,7 @@
 <div class="content-container" ng-controller="EditCenterController">
     <ul class="breadcrumb">
         <li><a href="#/centers">{{'label.anchor.centers' | translate}}</a></li>
-        <li><a href="#/viewcenter/{{centerId}}">{{'label.anchor.viewcentertranslate' | translate }}</a></li>
+        <li><a href="#/viewcenter/{{centerId}}">{{'label.anchor.viewcenter' | translate }}</a></li>
         <li class="active">{{'label.anchor.editcenter' | translate}}</li>
     </ul>
     <api-validate></api-validate>


### PR DESCRIPTION
Before fix #2208 
![image](https://cloud.githubusercontent.com/assets/8160209/25803008/a842fae6-33fd-11e7-866c-26010087d634.png)

After fix
![viewcenter](https://cloud.githubusercontent.com/assets/8160209/25803048/d897eda0-33fd-11e7-951c-1c4630ed889b.png)
