### PR TITLE
Reskin: Fix 2231 - Events details is not aligned in Manage Hooks

### DIFF
--- a/app/views/system/viewhook.html
+++ b/app/views/system/viewhook.html
@@ -69,7 +69,7 @@
                                 <table>
                                     <tr ng-repeat="event in hook.events">
                                         <td>
-                                            <span style="margin-left: -20px">{{event.actionName}} - {{event.entityName}}</span>
+                                            <span>{{event.actionName}} - {{event.entityName}}</span>
                                         </td>
                                     </tr>
                                 </table>


### PR DESCRIPTION
Before the fix #2231 
![managehook1](https://cloud.githubusercontent.com/assets/8160209/26053238/c09c0a9c-3970-11e7-9612-832f32b6c890.png)

After the fix
![managehook](https://cloud.githubusercontent.com/assets/8160209/26053244/c54da56e-3970-11e7-95da-39b5f0c9bddf.png)
