### PR TITLE
Reskin: Fix #1798 - Validation error readable

### DIFF
--- a/app/global-translations/locale-en.json
+++ b/app/global-translations/locale-en.json
@@ -1817,7 +1817,9 @@
     "error.msg.loan.disbursement.cannot.be.a.edited": "Disbursement details cannot be edited for a loan which is already disbursed",
     "error.msg.loan.product.does.not.support.multiple.disbursals": "This loan product does not support multiple disbursals",
     "error.msg.cannot.modify.tranches.if.loan.is.pendingapproval.closed.overpaid.writtenoff" : "Disbursement details cannot be modified if the loan account is Pending approval/Closed/Overpaid/WrittenOff",
-
+    "validation.msg.rescheduleloan.graceOnPrincipal.cannot.be.blank": "Select any one of the below options before submitting: \"Change Repayment Date\", \"Introduce Mid-term Grace Period\", \"Extend Repayment Period\", \"Adjust Interest rate for the remainder of loan\"",
+    "validation.msg.rescheduleloan.rescheduleFromDate.cannot.be.blank": "Reschedule From Date cannot be empty",
+    "validation.msg.rescheduleloan.rescheduleReasonId.cannot.be.blank": "Reason for Rescheduling cannot be empty",
 
     "#-------": "------------",
 


### PR DESCRIPTION
Fixed #1798 
Validation error added as per the comment.

Old 
![screen shot 2017-05-30 at 3 06 36 pm](https://cloud.githubusercontent.com/assets/7816559/26577382/e17c5476-4549-11e7-886c-53e61e0ab1ed.png)

New
![screen shot 2017-05-30 at 3 08 05 pm](https://cloud.githubusercontent.com/assets/7816559/26577394/eabdb16a-4549-11e7-98a9-c42aa0c05720.png)

To Verify: 
URL: [https://demo.openmf.org/newbeta/#/loans/1038/reschedule/](https://demo.openmf.org/newbeta/#/loans/1038/reschedule/)
Date: 22 June 2017