### PR TITLE
Reskin: Fix #2197 - View Receipt button not visible on hover 

### DIFF
--- a/app/views/loans/viewloanaccountdetails.html
+++ b/app/views/loans/viewloanaccountdetails.html
@@ -611,13 +611,13 @@
                                         {{transaction.outstandingLoanBalance | number}}
                                     </td>
 
-                                    <td> <a tooltip="{{'label.heading.viewreceipts' | translate }}" ng-if="transaction.manuallyReversed!=true" ng-click="viewloantransactionreceipts(transaction.id)">
+                                    <td> <span uib-tooltip="{{'label.heading.viewreceipts' | translate }}" ng-if="transaction.manuallyReversed!=true" ng-click="viewloantransactionreceipts(transaction.id)">
                                         <i class="fa fa-file-text fa fa-large"></i>
-                                    </a>
+                                    </span>
                                     </td>
-									 <td> <a tooltip="{{'label.anchor.viewjournalentries' | translate}}" ng-click="viewloantransactionjournalentries(transaction.id)">
-                                        <i class="fa fa-circle-arrow-right fa fa-large coll"></i>
-                                    </a>
+									 <td> <span uib-tooltip="{{'label.anchor.viewjournalentries' | translate}}" ng-click="viewloantransactionjournalentries(transaction.id)">
+                                        <i class="fa fa-arrow-circle-right fa fa-large coll"></i>
+                                    </span>
                                     </td>
                                 </tr>
                             </tbody>


### PR DESCRIPTION
Fix #2197, Fixed tooltip also. it was not showing.
Old 
![screen shot 2017-05-30 at 3 19 24 pm](https://cloud.githubusercontent.com/assets/7816559/26577921/a7872a28-454b-11e7-915e-f2e4c6ddd2ba.png)

New
![screen shot 2017-05-30 at 3 21 00 pm](https://cloud.githubusercontent.com/assets/7816559/26577926/ae303f22-454b-11e7-917a-a893ba0bb7ba.png)


URL: [https://demo.openmf.org/newbeta/#/viewloanaccount/1095](https://demo.openmf.org/newbeta/#/viewloanaccount/1095)