### PR TITLE
Reskin: Fix #1822 - No * for from date , to date and staff ID

### DIFF
--- a/app/views/organization/cashmgmt/createCashier.html
+++ b/app/views/organization/cashmgmt/createCashier.html
@@ -26,13 +26,16 @@
     			</div>
 
     			<div class="form-group">
-    				<label class="control-label col-sm-2">{{'label.heading.cashmgmt.tellerCashiers.cashierName' | translate}}</label>
+    				<label class="control-label col-sm-2">{{'label.heading.cashmgmt.tellerCashiers.cashierName' | translate}}<span class="required">*</span></label>
     				<div class="col-sm-3">
-    					<select chosen="cashier.staffOptions" id="staffId" ng-model="formData.staffId" class="form-control"
+    					<select chosen="cashier.staffOptions" id="staffId" name="staffId" ng-model="formData.staffId" class="form-control"
     							ng-options="staff.id as staff.displayName for staff in cashier.staffOptions"
-    							value="{{staff.id}}">
+    							value="{{staff.id}}" required late-validate>
     					</select>
     				</div>
+					<div class="col-sm-2">
+						<form-validate valattributeform="createcashierform" valattribute="staffId"/>
+					</div>
     			</div>
 
     			<div class="form-group">
@@ -43,19 +46,25 @@
     			</div>
 
     			<div class="form-group">
-    				<label class="control-label col-sm-2">{{ 'label.input.teller.cashier.startDate' | translate }}</label>
+    				<label class="control-label col-sm-2">{{ 'label.input.teller.cashier.startDate' | translate }}<span class="required">*</span></label>
     				<div class="col-sm-3">
-    					<input id="startDate" sort type="text" datepicker-pop="dd MMMM yyyy" ng-model="first.date"
-    						   class="form-control" is-open="opened" min="minDate" max="restrictDate"/>
+    					<input id="startDate" name="startDate" sort type="text" datepicker-pop="dd MMMM yyyy" ng-model="first.date"
+    						   class="form-control" is-open="opened" min="minDate" max="restrictDate" required late-validate/>
     				</div>
+					<div class="col-sm-2">
+						<form-validate valattributeform="createcashierform" valattribute="startDate"/>
+					</div>
     			</div>
 
     			<div class="form-group">
-    				<label class="control-label col-sm-2"> {{ 'label.input.teller.cashier.endDate' | translate }}</label>
+    				<label class="control-label col-sm-2"> {{ 'label.input.teller.cashier.endDate' | translate }}<span class="required">*</span></label>
     				<div class="col-sm-3">
-    					<input id="endDate" sort type="text" datepicker-pop="dd MMMM yyyy" ng-model="formData.endDate"
-    						   class="form-control" is-open="opened" min="minDate" />
+    					<input id="endDate" name="endDate" sort type="text" datepicker-pop="dd MMMM yyyy" ng-model="formData.endDate"
+    						   class="form-control" is-open="opened" min="minDate" required late-validate/>
     				</div>
+					<div class="col-sm-2">
+						<form-validate valattributeform="createcashierform" valattribute="endDate"/>
+					</div>
     			</div>
     			<div class="form-group">
     				<label class="control-label col-sm-2">{{ 'label.input.teller.cashier.fullDay' | translate }}</label>


### PR DESCRIPTION
Fixes #1822, No Asterisk for fields staff, from date and to date in create cashier form.

OLD:
![screen shot 2017-06-01 at 12 51 37 pm](https://cloud.githubusercontent.com/assets/7816559/26668841/21fab5e4-46c9-11e7-9257-0b478f9d3b80.png)

NEW:
![screen shot 2017-06-01 at 12 52 56 pm](https://cloud.githubusercontent.com/assets/7816559/26668886/4cda1854-46c9-11e7-9c55-170f74dcd312.png)


URL: [https://demo.openmf.org/newbeta/#/tellers/35/createCashierForTeller](https://demo.openmf.org/newbeta/#/tellers/35/createCashierForTeller)
