### PR TITLE
Reskin: Fix #1822 - Asterisks are missing in the fields of creation of Cashier to show mandatory fields

### DIFF
--- a/app/scripts/controllers/organization/cashmgmt/CreateCashierForTellerController.js
+++ b/app/scripts/controllers/organization/cashmgmt/CreateCashierForTellerController.js
@@ -12,6 +12,7 @@
 
             resourceFactory.tellerCashierTemplateResource.get({tellerId: routeParams.tellerId}, function (data) {
                 scope.cashier = data;
+                scope.formData.staffId = data.staffOptions[0].id;
             });
 
             scope.setChoice = function () {
@@ -35,7 +36,7 @@
                 this.formData.hourEndTime;
                 this.formData.minEndTime;
                 resourceFactory.tellerCashierResource.save(
-                    {'tellerId': routeParams.tellerId, 'cashierId': routeParams.cashierId}, 
+                    {'tellerId': routeParams.tellerId, 'cashierId': routeParams.cashierId},
                     this.formData, function (data) {
                         location.path('tellers/' + routeParams.tellerId + '/cashiers');
                 });

--- a/app/views/organization/cashmgmt/createCashier.html
+++ b/app/views/organization/cashmgmt/createCashier.html
@@ -26,7 +26,8 @@
     			</div>
 
     			<div class="form-group">
-    				<label class="control-label col-sm-2">{{'label.heading.cashmgmt.tellerCashiers.cashierName' | translate}}</label>
+    				<label class="control-label col-sm-2">{{'label.heading.cashmgmt.tellerCashiers.cashierName' | translate}}
+                    <span class="required">*</span></label>
     				<div class="col-sm-3">
     					<select chosen="cashier.staffOptions" id="staffId" ng-model="formData.staffId" class="form-control"
     							ng-options="staff.id as staff.displayName for staff in cashier.staffOptions"
@@ -43,19 +44,25 @@
     			</div>
 
     			<div class="form-group">
-    				<label class="control-label col-sm-2">{{ 'label.input.teller.cashier.startDate' | translate }}</label>
+    				<label class="control-label col-sm-2">{{ 'label.input.teller.cashier.startDate' | translate }}<span class="required">*</span></label>
     				<div class="col-sm-3">
-    					<input id="startDate" sort type="text" datepicker-pop="dd MMMM yyyy" ng-model="first.date"
-    						   class="form-control" is-open="opened" min="minDate" max="restrictDate"/>
+    					<input id="startDate" name="startDate" sort type="text" datepicker-pop="dd MMMM yyyy" ng-model="first.date"
+    						   class="form-control" is-open="opened" min="minDate" max="restrictDate" required/>
     				</div>
+                    <div class="col-sm-3">
+                        <form-validate valattributeform="createcashierform" valattribute="startDate"/>
+                    </div>
     			</div>
 
     			<div class="form-group">
-    				<label class="control-label col-sm-2"> {{ 'label.input.teller.cashier.endDate' | translate }}</label>
+    				<label class="control-label col-sm-2"> {{ 'label.input.teller.cashier.endDate' | translate }}<span class="required">*</span></label>
     				<div class="col-sm-3">
-    					<input id="endDate" sort type="text" datepicker-pop="dd MMMM yyyy" ng-model="formData.endDate"
-    						   class="form-control" is-open="opened" min="minDate" />
+    					<input id="endDate" name="endDate" sort type="text" datepicker-pop="dd MMMM yyyy" ng-model="formData.endDate"
+    						   class="form-control" is-open="opened" min="minDate" required/>
     				</div>
+                    <div class="col-sm-3">
+                        <form-validate valattributeform="createcashierform" valattribute="endDate"/>
+                    </div>
     			</div>
     			<div class="form-group">
     				<label class="control-label col-sm-2">{{ 'label.input.teller.cashier.fullDay' | translate }}</label>


### PR DESCRIPTION
Earlier UI:
![c1](https://cloud.githubusercontent.com/assets/20562458/26671475/8bb7f6c0-46ad-11e7-9303-d21f8b42cf90.png)

Previous UI:
![p1](https://cloud.githubusercontent.com/assets/20562458/26671484/92bf206a-46ad-11e7-9367-5fb4ae80cf91.png)

Affected View: https://demo.openmf.org#/tellers/35/createCashierForTeller