### PR TITLE
Reskin: Fix MIFOSX-2504 - In Create Floating Rate page fields have same ID attribute

### DIFF
--- a/app/views/products/floatingrates/CreateFloatingRate.html
+++ b/app/views/products/floatingrates/CreateFloatingRate.html
@@ -64,17 +64,17 @@
                 <tr ng-repeat="rateperiod in formData.ratePeriods">
                     <td>
                         <ng-form name="fromDate{{$index}}">
-                        <input type="text" id="fromDate1" name="fromDate1" datepicker-pop="dd MMMM yyyy"
+                        <input type="text" id="fromDate{{$index}}" name="fromDate" datepicker-pop="dd MMMM yyyy"
                                ng-model="rateperiod.fromDate" is-open="opened" min="'2000-01-01'" max="restrictDate"
                                class="form-control" required/>
-                            <span class="error" ng-show="visitValidation&&fromDate{{$index}}.fromDate1.$error.required">{{ 'label.requirefield' | translate }}</span>
+                            <span class="error" ng-show="visitValidation&&fromDate{{$index}}.fromDate.$error.required">{{ 'label.requirefield' | translate }}</span>
                         </ng-form>
                     </td>
                     <td>
                         <ng-form name="interestRate{{$index}}">
-                            <input id="interestRate1" name="interestRate1" class="form-control" type="text"
+                           <input id="interestRate{{$index}}" name="interestRate" class="form-control" type="text"
                                    ng-model="rateperiod.interestRate" number-format required/>
-                            <span class="error" ng-show="visitValidation&&interestRate{{$index}}.interestRate1.$error.required">{{ 'label.requirefield' | translate }}</span>
+                            <span class="error" ng-show="visitValidation&&interestRate{{$index}}.interestRate.$error.required">{{ 'label.requirefield' | translate }}</span>
                         </ng-form>
                     </td>
                     <td>


### PR DESCRIPTION
Go to Admin->Products->Floating rates->Create Floating Rates, then click on 'Add' button more than 2 times
Inspect calendar fields - they have same ID attribute.

![same id for all fields](https://user-images.githubusercontent.com/22119535/26872228-7aff1a9a-4b7e-11e7-9797-eeec7c7a47f5.png)

