### PR TITLE
Fix #2292 - Reskin:The buttons doesn't show direction of tags in Accounting Rule

### DIFF
--- a/app/views/accounting/add_acc_rule.html
+++ b/app/views/accounting/add_acc_rule.html
@@ -92,9 +92,9 @@
                                             <select ng-model="availableCredit" multiple class="form-control clear" ng-options="creditTag.name for creditTag in creditTagOptions"></select>
                                         </div>
                                         <div class="col-sm-1 col-md-1 paddedtop25px">
-                                            <button type="button" class="btn btn-primary" data-ng-click="addCreditTag()"><i class="icon-double-angle-right"></i>
+                                            <button type="button" class="btn btn-primary" data-ng-click="addCreditTag()"><i class="fa fa-angle-double-right"></i>
                                             </button>
-                                            <button type="button" class="btn btn-primary" data-ng-click="removeCreditTag()"><i class="icon-double-angle-left"></i>
+                                            <button type="button" class="btn btn-primary" data-ng-click="removeCreditTag()"><i class="fa fa-angle-double-left"></i>
                                             </button>
                                         </div>
                                         <div class="col-sm-5 col-md-5">

--- a/app/views/accounting/edit_acc_rule.html
+++ b/app/views/accounting/edit_acc_rule.html
@@ -65,9 +65,9 @@
                                            </div>
                                            <div class="col-sm-1 col-md-1 paddedtop25px">
                                                <button type="button" class="btn btn-primary" data-ng-click="addDebitTag()"><i
-                                                       class="fa fa-double-angle-right"></i></button>
+                                                       class="fa fa-angle-double-right"></i></button>
                                                <button type="button" class="btn btn-primary" data-ng-click="removeDebitTag()"><i
-                                                       class="fa fa-double-angle-left"></i></button>
+                                                       class="fa fa-angle-double-left"></i></button>
                                            </div>
                                            <div class="col-sm-5 col-md-5">
                                                <label class="control-label col-sm-12 center">{{ 'label.input.selecteddebittags' | translate }}</label>
@@ -97,9 +97,9 @@
                                            </div>
                                            <div class="col-sm-1 col-md-1 paddedtop25px">
                                                <button type="button" class="btn btn-primary" data-ng-click="addCreditTag()"><i
-                                                       class="fa fa-double-angle-right"></i></button>
+                                                       class="fa fa-angle-double-right"></i></button>
                                                <button type="button" class="btn btn-primary" data-ng-click="removeCreditTag()"><i
-                                                       class="fa fa-double-angle-left"></i></button>
+                                                       class="fa fa-angle-double-left"></i></button>
                                            </div>
                                            <div class="col-sm-5 col-md-5">
                                                <label class="control-label col-sm-12 center">{{ 'label.input.selectedcredittags' | translate }}</label>


### PR DESCRIPTION
In Creating Accounting Rule
Before fix #2292 
![accrulearrow2](https://user-images.githubusercontent.com/8160209/26971338-5f2916e8-4d15-11e7-95f1-3ac1a8a99cb9.png)

After the fix
![accrulearrow5](https://user-images.githubusercontent.com/8160209/26971358-6f0333dc-4d15-11e7-9b83-f05b1ad90a0a.png)

In Editing the Accounting Rule
Before the fix
![accrulearrow](https://user-images.githubusercontent.com/8160209/26971374-855bc888-4d15-11e7-9cae-11371decf93b.png)

After the fix
![accrulearrow4](https://user-images.githubusercontent.com/8160209/26971383-936962f0-4d15-11e7-8df4-d118817f619c.png)
