### PR TITLE
Fix 2296 - Reskin: Button for shifting role to be selected doesn't show direction in edit page

### DIFF
--- a/app/views/administration/edituser.html
+++ b/app/views/administration/edituser.html
@@ -104,10 +104,10 @@
                 </div>
                 <div class="col-sm-1 col-md-1 paddedtop25px">
                     <button type="button" class="btn btn-primary" data-ng-click="addRole()"><i
-                            class="icon-double-angle-right"></i></button>
+                            class="fa fa-angle-double-right"></i></button>
                     <br/>
                     <button type="button" class="btn btn-primary" data-ng-click="removeRole()"><i
-                            class="icon-double-angle-left"></i></button>
+                            class="fa fa-angle-double-left"></i></button>
                 </div>
                 <div class="col-sm-3 col-md-3">
                     <label class="control-label col-sm-9">{{ 'label.input.selectedroles' | translate}}</label>


### PR DESCRIPTION
Before fix issue #2296
![userarrow](https://user-images.githubusercontent.com/8160209/26977503-d2371ac0-4d30-11e7-8963-18be7cfbf14a.png)

After the fix
![userarror1](https://user-images.githubusercontent.com/8160209/26977520-dd1c61b6-4d30-11e7-88d8-b071210a1f10.png)
