### PR TITLE
Reskin: Fix #2304 - Remove * from submittedon

### DIFF
--- a/app/views/clients/editclient.html
+++ b/app/views/clients/editclient.html
@@ -239,8 +239,7 @@
 			</div>
 
             <div class="form-group">
-                <label class="control-label col-sm-2">{{'label.input.submittedon' | translate}}:<span
-                        class="required">*</span></label>
+                <label class="control-label col-sm-2">{{'label.input.submittedon' | translate}}:</label>
 
                 <div class="col-sm-3">
                     <input id="submittedOnDate" type="text" name="submittedOnDate" datepicker-pop="dd MMMM yyyy"


### PR DESCRIPTION
Removed required label from the submitted on in edit client as it is not mandatory