### PR TITLE
Fix #2328 - Reskin: Delete icon doesn't display for charge overview

### DIFF
--- a/app/styles/styles.css
+++ b/app/styles/styles.css
@@ -6038,7 +6038,7 @@ button.close {
 .fa-cog:before {
   content: ""; }
 
-.fa-trash-o:before {
+.fa-trash:before {
   content: ""; }
 
 .fa-home:before {


### PR DESCRIPTION
Added the icon for delete
![deletecharge2](https://user-images.githubusercontent.com/8160209/27474892-fa1af1b6-580b-11e7-8919-0687055d9582.png)
