### PR TITLE
Fix #2308 - Reskin: Not understandable error when "Link savings" is blank during loan application 

### DIFF
--- a/app/global-translations/locale-en.json
+++ b/app/global-translations/locale-en.json
@@ -1689,6 +1689,7 @@
     "loanStatusType.witharrears":"In arrears",
     "validation.msg.loan.productId.cannot.be.blank": "Product is mandatory.",
     "validation.msg.loan.productId.not.greater.than.zero": "Selected product is invalid.",
+    "validation.msg.loan.linkAccountId.cannot.be.blank": "'Link to savings' can not be blank when 'Create standing structions at disbursement' is selected.",
     "validation.msg.loan.principal.cannot.be.blank": "Loan amount is mandatory.",
     "validation.msg.loan.principal.not.greater.than.zero": "Loan amount must be greater than zero.",
     "validation.msg.loan.loanTermFrequency.cannot.be.blank": "Loan term is mandatory.",


### PR DESCRIPTION
Before fix
![linktosavin](https://user-images.githubusercontent.com/8160209/29316615-63551c94-81d1-11e7-9725-aabc0a3577e7.png)

After the fix
![linktosaving](https://user-images.githubusercontent.com/8160209/29316643-6ee46ad8-81d1-11e7-9e0c-5362f1da9734.png)
