### PR TITLE
Fix #2436 : View account transfer detail page is not showing proper label

### DIFF
--- a/app/views/accounttransfers/view_accounttransfer.html
+++ b/app/views/accounttransfers/view_accounttransfer.html
@@ -1,7 +1,7 @@
 <div class="content-container" ng-controller="ViewAccountTransferDetailsController">
     <ul class="breadcrumb">
         <li><a href="#/viewsavingaccount/{{transferData.fromAccount.id}}">{{'label.anchor.viewsavingaccount' | translate}}</a></li>
-        <li class="active">{{'label.anchor.viewaccounttransferdetailstranslate' | translate}}</li>
+        <li class="active">{{'label.anchor.viewaccounttransferdetails' | translate}}</li>
     </ul>
     <div class="card">
         <div class="content">


### PR DESCRIPTION
Before fix 
![viewacctrns](https://user-images.githubusercontent.com/8160209/29877892-9822d9be-8da9-11e7-9aa1-6c95b3eff54c.png)

After the fix
![viewacctransfa1](https://user-images.githubusercontent.com/8160209/29877907-a3dc8458-8da9-11e7-9b8d-455103a1859c.png)
