### PR TITLE
Fix #2449 - Asterick is missing in the field of creation of loan product to show mandatory field

### DIFF
--- a/app/views/products/createloanproduct.html
+++ b/app/views/products/createloanproduct.html
@@ -371,6 +371,7 @@
 </div>
 <div class="form-group" ng-show="!formData.isLinkedToFloatingInterestRates">
     <label class="control-label col-sm-2">{{ 'label.input.nominalinterestrate' | translate }}
+     <span class="required">*</span>
         <i class="fa fa-question-sign" tooltip="{{'label.tooltip.loanproduct.nominalinterestrate' | translate}}"
            tooltip-append-to-body="true"></i>
     </label>


### PR DESCRIPTION
Before Fix #2449
![nominalinterest1](https://user-images.githubusercontent.com/8160209/30030193-e346b9ee-9194-11e7-9edf-3a1d62410a9b.png)

After fix
![nominalinterest](https://user-images.githubusercontent.com/8160209/30030198-e7f8df4e-9194-11e7-9cd5-725f2ae8ff19.png)
