### PR TITLE
Fix  #2448: Waive loan charge page is not showing proper label

### DIFF
--- a/app/global-translations/locale-en.json
+++ b/app/global-translations/locale-en.json
@@ -1428,6 +1428,7 @@
     "label.anchor.disbursetosavings":"Disburse To Savings",
     "label.anchor.repayment": "Repayment",
     "label.anchor.waiveinterest": "Waive Interest",
+    "label.anchor.waivecharge": "Waive Charge",
     "label.anchor.writeoff": "Write Off",
     "label.anchor.close-rescheduled": "Close Rescheduled",
     "label.anchor.modifytransaction": "Modify Transaction",


### PR DESCRIPTION
Before the fix
![waivechargee](https://user-images.githubusercontent.com/8160209/30097117-b58ba5d6-92e4-11e7-9c10-e9a5947b9826.png)

After the fix
![waivecharge](https://user-images.githubusercontent.com/8160209/30097121-ba084cf4-92e4-11e7-89e1-d681ac768c89.png)
