### PR TITLE
Fix #2453: Label for delete charge icon is not proper

### DIFF
--- a/app/global-translations/locale-en.json
+++ b/app/global-translations/locale-en.json
@@ -344,6 +344,7 @@
     "label.relDate": "Mifos X Release Date: ",
     "label.relVersion": "Release Version: ",
     "label.select":"Select an Option",
+    "label.delete": "Delete",
 
     "#Enumeration & Error Messages": "..",
     "label.error": "Error",


### PR DESCRIPTION
Before the fix
![deletelabel](https://user-images.githubusercontent.com/8160209/30097450-65d06ffc-92e6-11e7-907e-0343bb133d80.png)

After the fix
![deletelabell](https://user-images.githubusercontent.com/8160209/30097454-68bd2bb0-92e6-11e7-8b9c-386eb196e8bb.png)
