### PR TITLE
Fix #2454: A label in a client profile to identify if s/he is a staff is not proper

### DIFF
--- a/app/views/clients/viewclient.html
+++ b/app/views/clients/viewclient.html
@@ -553,8 +553,8 @@
 										</td>
 									</tr>
                                     <tr>
-                                        <th class="table-bold">{{ 'label.input.isstaff' | translate }}</th>
-                                        <td><span class="padded-td">{{client.isstaff}}</span>
+                                        <th class="table-bold">{{ 'label.input.isStaff' | translate }}</th>
+                                        <td><span class="padded-td">{{client.isStaff}}</span>
                                         </td>
                                     </tr>
 									<tr data-ng-show="client.mobileNo">


### PR DESCRIPTION
Before the fix
![clientprofile](https://user-images.githubusercontent.com/8160209/30097822-2a776e7c-92e8-11e7-81b4-05812e50dd5d.png)

After the fix
![clientprofile](https://user-images.githubusercontent.com/8160209/30097834-3748d37a-92e8-11e7-9407-3d7d6f63c1cd.png)
