### PR TITLE
Fix #2444: Share to be issued doesn't show it is mandatory

### DIFF
--- a/app/views/products/createshareproduct.html
+++ b/app/views/products/createshareproduct.html
@@ -87,7 +87,7 @@
         <form-validate valattributeform="createshareproductform" valattribute="totalnumberofshares"/>
     </div>
 
-    <label class="control-label col-sm-2">{{ 'label.input.totalsharestobeissue' | translate }}</label>
+    <label class="control-label col-sm-2">{{ 'label.input.totalsharestobeissue' | translate }}<span class="required">*</span></label></label>
     <i class="fa fa-question-circle col-sm-1" uib-tooltip="{{'label.tooltip.totalsharestobeissued' | translate}}"></i>
 
     <div class="col-sm-2">

--- a/app/views/products/editshareproduct.html
+++ b/app/views/products/editshareproduct.html
@@ -87,7 +87,7 @@
         <form-validate valattributeform="createshareproductform" valattribute="totalnumberofshares"/>
     </div>
 
-    <label class="control-label col-sm-2">{{ 'label.input.totalsharestobeissue' | translate }}</label>
+    <label class="control-label col-sm-2">{{ 'label.input.totalsharestobeissue' | translate }}<span class="required">*</span></label></label>
     <i class="fa fa-question-circle col-sm-1" uib-tooltip="{{'label.tooltip.totalsharestobeissued' | translate}}"></i>
 
     <div class="col-sm-2">


### PR DESCRIPTION
When creating and editing share product
![sharetobeissued](https://user-images.githubusercontent.com/8160209/30853687-2eba12b6-a2b8-11e7-87b0-735b242319e8.png)
