### PR TITLE
Fix#2493 :To fetch the current date when assigning loan officer

### DIFF
--- a/app/scripts/controllers/loanAccount/AssignLoanOfficerController.js
+++ b/app/scripts/controllers/loanAccount/AssignLoanOfficerController.js
@@ -6,6 +6,8 @@
             scope.formData = {};
             scope.loanId = routeParams.id;
             var fields = "id,loanOfficerId,loanOfficerOptions";
+            scope.formData.assignmentDate = new Date();
+            scope.restrictDate = new Date();
 
             resourceFactory.loanResource.get({loanId: scope.loanId, template: true, fields: fields, staffInSelectedOfficeOnly:true}, function (data) {
                 if (data.loanOfficerOptions) {

--- a/app/views/loans/assignloanofficer.html
+++ b/app/views/loans/assignloanofficer.html
@@ -28,7 +28,7 @@
 
                     <div class="col-sm-3">
                         <input class="form-control" sort id="assignmentDate" type="text" datepicker-pop="dd MMMM yyyy"
-                               ng-model="formData.assignmentDate" is-open="opened" min="minDate" max="'2020-06-22'"/>
+                               ng-model="formData.assignmentDate" is-open="opened" max="restrictDate"/>
                     </div>
                 </div>
                 <div class="col-md-offset-3">


### PR DESCRIPTION
Hi @mbj36 I made two changes Fix #2493 

- Enabling fetching the current date

- Restrict Adding the future date, because if you set the Assignment Date is tomorrow(any ..future date) it brings error(Not possible)..see the screenshot below
![off](https://user-images.githubusercontent.com/13551795/31275514-34df9342-aaa0-11e7-93a8-1bd196f6e6d7.png)

so I thought It is better disallow it, because it(future date) has no use.
Can you take a look at it?
