### PR TITLE
Fix#1822: Reskin&oldSkin: Asterisks are missing in the fields of creation of Cashier to show mandatory fields

### DIFF
--- a/app/views/organization/cashmgmt/editcashier.html
+++ b/app/views/organization/cashmgmt/editcashier.html
@@ -43,7 +43,7 @@
             </div>
 
             <div class="form-group">
-                <label class="control-label col-sm-2">{{ 'label.input.teller.cashier.startDate' | translate }}</label>
+                <label class="control-label col-sm-2">{{ 'label.input.teller.cashier.startDate' | translate }}<span class="required">*</span></label>
                 <div class="col-sm-3">
                     <input id="startDate" sort type="text" datepicker-pop="dd MMMM yyyy" ng-model="formData.startDate"
                            class="form-control" is-open="opened" min="minDate" max="restrictDate"/>
@@ -51,7 +51,7 @@
             </div>
 
             <div class="form-group">
-                <label class="control-label col-sm-2"> {{ 'label.input.teller.cashier.endDate' | translate }}</label>
+                <label class="control-label col-sm-2"> {{ 'label.input.teller.cashier.endDate' | translate }}<span class="required">*</span></label>
                 <div class="col-sm-3">
                     <input id="endDate" sort type="text" datepicker-pop="dd MMMM yyyy" ng-model="formData.endDate"
                            class="form-control" is-open="opened" min="minDate" />


### PR DESCRIPTION
Fix #1822 
![cashier3](https://user-images.githubusercontent.com/13551795/31345188-9e59c0a2-ad1d-11e7-8be5-72642e3655cd.png)

