### PR TITLE
Fix #2423 : The payment type has a mandatory sign but allow to submit when it is empty

### DIFF
--- a/app/views/loans/loanaccountactions.html
+++ b/app/views/loans/loanaccountactions.html
@@ -172,8 +172,7 @@
                 <div ng-show="isTransaction">
                     <div class="form-group">
                         <label class="control-label col-sm-2" for="paymentTypeId">{{ 'label.input.paymenttype' |
-                            translate}}<span
-                                    class="required">*</span></label>
+                            translate}}</label>
 
                         <div class="col-sm-3">
                             <select id="paymentTypeId" ng-model="formData.paymentTypeId" class="form-control"


### PR DESCRIPTION
Removed the asterisk sign to the field of payment type 