### PR TITLE
Fix #2536 : Can't see all reschedule loans when want to approve

### DIFF
--- a/app/scripts/controllers/main/TaskController.js
+++ b/app/scripts/controllers/main/TaskController.js
@@ -16,7 +16,7 @@
             //this value will be changed within each specific tab
             scope.requestIdentifier = "loanId";
 
-            scope.itemsPerPage = 15;
+            scope.itemsPerPage = 1000;
 
             scope.loanRescheduleData = [];
             scope.checkForBulkLoanRescheduleApprovalData = [];


### PR DESCRIPTION
Fixed the issue by changing the items to be listed on the page from 15 to 1000 asuming the reschedule won't reach 1000 and so all can be displayed.