### PR TITLE
Fixed #1669 - Camera Stays 'On' Even After Uploading A Captured Profile pic.

### DIFF
--- a/app/scripts/controllers/client/ViewClientController.js
+++ b/app/scripts/controllers/client/ViewClientController.js
@@ -315,10 +315,15 @@
                     videoWidth: 320,
                     videoHeight: 240
                 };
+                $scope.stream = null;
 
                 $scope.onVideoSuccess = function () {
                     $scope.error = null;
                 };
+                
+                $scope.onStream = function(stream) {
+                    $scope.stream = stream
+                }
 
                 $scope.onVideoError = function (err) {
                     if(typeof err != "undefined")
@@ -350,6 +355,7 @@
                             if (!scope.$$phase) {
                                 scope.$apply();
                             }
+                            $scope.stream.getVideoTracks()[0].stop();
                             $uibModalInstance.close('upload');
                             route.reload();
                         });
@@ -357,6 +363,7 @@
                 };
                 $scope.cancel = function () {
                     $uibModalInstance.dismiss('cancel');
+                    $scope.stream.getVideoTracks()[0].stop();
                 };
                 $scope.reset = function () {
                     $scope.picture = null;

--- a/app/views/clients/viewclient.html
+++ b/app/views/clients/viewclient.html
@@ -66,7 +66,7 @@
 			<div>
 				<div class="left">
 					<webcam on-streaming="onVideoSuccess()"
-							on-error="onVideoError(err)" channel="videoChannel"></webcam>
+							on-error="onVideoError(err)" on-stream="onStream(stream)" channel="videoChannel"></webcam>
 				</div>
 				<div class="right">
 					<canvas id="clientSnapshot" width="320" height="240"></canvas>


### PR DESCRIPTION
With these changes, the webcam now turns off when either the "cancel" or "upload" buttons are pressed on a "viewclient" page. https://i.imgur.com/GJO3vAH.png -> https://i.imgur.com/URjVkuC.png