### PR TITLE
Fixed #2419 - Ability to edit and delete a note from Notes in client profile

### DIFF
--- a/app/scripts/controllers/client/ViewClientController.js
+++ b/app/scripts/controllers/client/ViewClientController.js
@@ -673,11 +673,72 @@
                 resourceFactory.clientResource.save({clientId: routeParams.id, anotherresource: 'notes'}, this.formData, function (data) {
                     var today = new Date();
                     temp = { id: data.resourceId, note: scope.formData.note, createdByUsername: "test", createdOn: today };
-                    scope.clientNotes.push(temp);
+                    scope.clientNotes.unshift(temp);
                     scope.formData.note = "";
                     scope.predicate = '-id';
                 });
             }
+
+            scope.showEditNote = function(clientId, clientNote, index) {
+                $uibModal.open({
+                    templateUrl: 'editNote.html',
+                    controller: EditNoteCtrl,
+                    resolve: {
+                        items: function(){
+                            return {
+                                clientId: clientId,
+                                clientNote: clientNote,
+                                index: index
+                            }
+                        }
+                    },
+                    size: "lg"
+                });
+            }
+
+            scope.showDeleteNote = function(clientId, clientNote, index) {
+                $uibModal.open({
+                    templateUrl: 'deleteNote.html',
+                    controller: DeleteNoteCtrl,
+                    resolve: {
+                        items: function(){
+                            return {
+                                clientId: clientId,
+                                clientNote: clientNote,
+                                index: index
+                            }
+                        }
+                    },
+                    size: "lg"
+                });
+            }
+            
+            var EditNoteCtrl = function ($scope, $uibModalInstance, items) {
+                scope.editData = {};
+                editData = {};
+                $scope.editNote = function (clientId, entityId, index, editData) {
+                    resourceFactory.clientNotesResource.put({clientId: items.clientId, noteId: items.clientNote}, {note: this.editData.editNote}, function(data) {
+                        scope.clientNotes[items.index].note = $scope.editData.editNote;
+                        scope.editData.editNote = "";
+                        $uibModalInstance.close();
+                    });
+                };
+                $scope.cancel = function (index) {
+                    $uibModalInstance.dismiss('cancel');
+                };
+            };
+            
+            var DeleteNoteCtrl = function ($scope, $uibModalInstance, items) {
+                $scope.deleteNote = function (clientId, entityId, index) {
+                    resourceFactory.clientNotesResource.delete({clientId: items.clientId, noteId: items.clientNote}, '', function(data) {
+                        $uibModalInstance.close();
+                        scope.clientNotes.splice(items.index, 1);
+                    });
+                };
+                $scope.cancel = function (index) {
+                    $uibModalInstance.dismiss('cancel');
+                };
+            };
 
             scope.deleteClientIdentifierDocument = function (clientId, entityId, index) {
                 resourceFactory.clientIdenfierResource.delete({clientId: clientId, id: entityId}, '', function (data) {

--- a/app/scripts/services/ResourceFactoryProvider.js
+++ b/app/scripts/services/ResourceFactoryProvider.js
@@ -65,8 +65,10 @@
                     clientAccountResource: defineResource(apiVer + "/clients/:clientId/accounts", {clientId: '@clientId'}, {
                         getAllClients: {method: 'GET', params: {}}
                     }),
-                    clientNotesResource: defineResource(apiVer + "/clients/:clientId/notes", {clientId: '@clientId'}, {
-                        getAllNotes: {method: 'GET', params: {}, isArray: true}
+                    clientNotesResource: defineResource(apiVer + "/clients/:clientId/notes/:noteId", {clientId: '@clientId', noteId: '@noteId'}, {
+                        getAllNotes: {method: 'GET', params: {}, isArray: true},
+                        delete:{method:'DELETE',params:{}},
+                        put:{method:'PUT',params:{}}
                     }),
                     clientTemplateResource: defineResource(apiVer + "/clients/template", {}, {
                         get: {method: 'GET', params: {}}

--- a/app/views/clients/viewclient.html
+++ b/app/views/clients/viewclient.html
@@ -120,6 +120,34 @@
 			<button class="btn btn-primary" ng-click="upload(file)">{{'label.button.upload' | translate}}</button>
 		</div>
 	</script>
+	<script type="text/ng-template" id="deleteNote.html">
+		<div class="modal-header silver">
+			<h3 class="bolder">{{'label.heading.delete' | translate}}</h3>
+		</div>
+		<div class="modal-body">
+			<p>{{'label.areyousure' | translate}}</p>
+		</div>
+		<div class="modal-footer">
+			<span class="pull-right">
+				<button class="btn btn-warning" ng-click="cancel()">{{'label.button.cancel' | translate}}</button>
+				<button class="btn btn-primary" ng-click="deleteNote(client.id,clientNote.id,$index)">{{'label.button.confirm' | translate}}</button>
+			</span>
+		</div>
+	</script>
+	<script type="text/ng-template" id="editNote.html">
+		<div class="modal-header silver">
+			<h3 class="bolder">{{'label.edit' | translate}}</h3>
+		</div>
+		<div class="modal-body">
+			<textarea rows="1" class="form-control marginbottom0px" id="textarea" placeholder="{{'label.input.enternote' | translate}}" ng-model="this.editData.editNote">  </textarea>
+		</div>
+		<div class="modal-footer">
+			<span class="pull-right">
+				<button class="btn btn-warning" ng-click="cancel()">{{'label.button.cancel' | translate}}</button>
+				<button class="btn btn-primary" ng-click="editNote(client.id,clientNote.id,$index)">{{'label.button.confirm' | translate}}</button>
+			</span>
+		</div>
+	</script>
 	<div class="card">
 		<div class="content">
 			<div class="toolbar">
@@ -1031,8 +1059,11 @@
 					<br/>
 					<div ng-repeat="clientNote in clientNotes | orderBy:predicate:reverse">
 						<blockquote>
-							<p>{{clientNote.note}}</p>
-							{{clientNote.id}}
+							<span class="pull-right noteaddbuttonwrapper btn-group">
+								<button class="btn btn-primary" type="submit" ng-click="showEditNote(client.id,clientNote.id,$index)" has-permission='CREATE_CLIENTNOTE'><i class="fa fa-edit"></i>{{'label.button.edit' |translate}}</button>
+								<button class="btn btn-danger" ng-click="showDeleteNote(client.id,clientNote.id,$index)" has-permission='DELETE_CLIENTNOTE'><i class="fa fa-trash-o"></i>{{'label.button.delete' |translate}}</button>
+							</span>
+							<p>{{$index + 1}}. {{clientNote.note}}</p>
 							<small>{{'label.createdby' | translate}} :&nbsp;{{clientNote.createdByUsername}}</small>
 							<small>{{'label.createdon' | translate}} :&nbsp;{{clientNote.createdOn | DateFormat}}</small>
 						</blockquote>


### PR DESCRIPTION
Added functionality to edit or delete a previously written note on the 'viewclient' screen.  Deletes/changes notes in both the scope and the backend (thru API). See screenshot:

![screencapture-mifos-k4tz-c9users-io-1512702617700](https://user-images.githubusercontent.com/23515048/33749325-fb5d5808-db81-11e7-902d-f8715ff44d82.png)

