### PR TITLE
Fixed #2465 - Corrected Redeem Shares Heading

### DIFF
--- a/app/scripts/controllers/shares/ShareAccountActionsController.js
+++ b/app/scripts/controllers/shares/ShareAccountActionsController.js
@@ -104,7 +104,7 @@
                         scope.shareaccountdetails = data;
                         scope.formData.unitPrice = data.currentMarketPrice ;
                     }) ;
-                    scope.title = 'label.heading.applyadditionalshares';
+                    scope.title = 'label.button.redeemshares';
                     scope.labelName = 'label.input.requesteddate';
                     scope.modelName = 'requestedDate';
                     scope.showDateField = true;


### PR DESCRIPTION
Client > New Share Account > Approve > Activate >Redeem Shares, heading now reads "Redeem Shares" instead of "Apply Additional Shares".  See screenshot:

![screenshot 4](https://user-images.githubusercontent.com/23515048/33793206-649bef0a-dc68-11e7-8600-3c76099d67f6.jpeg)
