### PR TITLE
Fixed #2559 - Hide options when client transfer on hold

### DIFF
--- a/app/views/clients/viewclient.html
+++ b/app/views/clients/viewclient.html
@@ -190,11 +190,11 @@
                                     <ul class="dropdown dropdown-menu dropdown-menu-right">
 										<li class="{{button.icon}}" ng-repeat="button in buttonsArray.options">
 											<a href="#/clientscreenreport/{{client.id}}"
-											   has-permission='{{button.taskPermissionName}}'>{{'label.'+ button.name |
+											   has-permission='{{button.taskPermissionName}}' ng-show="client.status.value!='Transfer on hold'">{{'label.'+ button.name |
 												translate}}</a>
 										</li>
 										<li>
-											<a data-ng-click="uploadSig()" has-permission='CREATE_CLIENTIMAGE'>{{'label.button.uploadsig'
+											<a data-ng-click="uploadSig()" has-permission='CREATE_CLIENTIMAGE' ng-show="client.status.value!='Transfer on hold'">{{'label.button.uploadsig'
 												| translate}}</a>
 										</li>
 										<li data-ng-show="clientAccounts.savingsAccounts">
@@ -202,7 +202,7 @@
 												| translate}}</a>
 										</li>
 										<li data-ng-show="clientAccounts.savingsAccounts">
-											<a data-ng-click="createstandinginstruction()" has-permission='READ_STANDINGINSTRUCTION'>{{'label.button.createstandinginstruction'
+											<a data-ng-click="createstandinginstruction()" has-permission='READ_STANDINGINSTRUCTION' ng-show="client.status.value!='Transfer on hold'">{{'label.button.createstandinginstruction'
 												| translate}}</a>
 										</li>
                                         <li data-ng-show="client.status.value=='Active'">


### PR DESCRIPTION
## Description
The options "Client screen report", "Create standing instructions", and "Upload client signature" have been hidden when client's status is "Transfer on hold".  These were previously usable on the front-end, but non-functional on the back end.  To minimize confusion, these options are now hidden.

## Related issues and discussion
Fix for issue #2559.

## Screenshots
Old: 
![image](https://user-images.githubusercontent.com/23515048/34082439-638705a8-e313-11e7-9e64-ae2b73be74c2.png)
New:
![screenshot 10](https://user-images.githubusercontent.com/23515048/34082419-08768648-e313-11e7-93b4-5fcb326cd9af.jpeg)