### PR TITLE
Correction in viewing group closed savings

### DIFF
--- a/app/views/groups/viewgroup.html
+++ b/app/views/groups/viewgroup.html
@@ -366,8 +366,8 @@
 							                	{{savingaccount.accountNo}}
 							                </td>
 							                <td class="pointer" data-ng-click="routeToSaving(savingaccount.id)">{{savingaccount.productName}}</td>
-							                <td class="pointer" data-ng-click="routeToSaving(savingaccount.id, savingaccount.depositType.code)">
-							                    <span data-ng-show="savingaccount.timeline.closedOnDate">{{savingaccount.timeline.closedOnDate | DateFormat}}</span>
+							                <td class="pointer" data-ng-click="routeToSaving(savingaccount.id, savingaccount.depositType.code)">{{ savingaccount.status.value }}</td>
+                                            <td data-ng-show="savingaccount.timeline.closedOnDate">{{savingaccount.timeline.closedOnDate | DateFormat}}
 							                </td>
 							            </tr>
 							            </tbody>


### PR DESCRIPTION
fixed #2669

## Description
Fixed the wrong data display in status and closing date column in group closed savings.

## Related issues and discussion
#2669 

## Screenshots, if any
![screenshot at 2017-12-20 00 31 08](https://user-images.githubusercontent.com/21126132/34173964-4678aad2-e51d-11e7-8f9f-af8f4d5c330b.png)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

-  [ ] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [ ] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `community-app/Contributing.md`.
