### PR TITLE
Fix for FINERACT-544 Issue - Delete client signature

### DIFF
--- a/app/global-translations/locale-en.json
+++ b/app/global-translations/locale-en.json
@@ -659,6 +659,7 @@
   "label.button.capturepic": "Capture Client Image",
   "label.button.deletepic": "Delete Client Image",
   "label.button.uploadsig": "Upload Client Signature",
+  "label.button.deletesig": "Delete Client Signature",
   "label.button.viewsig": "View Client Signature",
   "label.button.viewactiveloans": "View Active Loans",
   "label.button.viewactivesavings": "View Active Savings",

--- a/app/scripts/controllers/client/ViewClientController.js
+++ b/app/scripts/controllers/client/ViewClientController.js
@@ -422,6 +422,42 @@
                     $uibModalInstance.dismiss('cancel');
                 };
             };
+            
+            scope.deleteSig = function () {
+                $uibModal.open({
+                    templateUrl: 'deletesig.html',
+                    controller: DeleteSigCtrl
+                });
+            };
+            var DeleteSigCtrl = function ($scope, $uibModalInstance) {
+                http({
+                        method: 'GET',
+                        url: $rootScope.hostUrl + API_VERSION + '/clients/' + routeParams.id + '/documents'
+                    }).then(function (docsData) {
+                        $scope.docId = -1;
+                        for (var i = 0; i < docsData.data.length; ++i) {
+                            if (docsData.data[i].name == 'clientSignature') {
+                                $scope.docId = docsData.data[i].id;
+                                scope.signature_url = $rootScope.hostUrl + API_VERSION + '/clients/' + routeParams.id + '/documents/' + docId + '/attachment?tenantIdentifier=' + $rootScope.tenantIdentifier;
+                            }
+                        }
+                    });
+                $scope.delete = function (file) {
+                    http({
+                        method: 'DELETE',
+                        url: $rootScope.hostUrl + API_VERSION + '/clients/' + routeParams.id + '/documents/' + $scope.docId
+                    }).then(function () {
+                        if (!scope.$$phase) {
+                                scope.$apply();
+                            }
+                            $uibModalInstance.close('upload');
+                            route.reload();
+                    });
+                };
+                $scope.cancel = function () {
+                    $uibModalInstance.dismiss('cancel');
+                };
+            };
 
             scope.unassignStaffCenter = function () {
                 $uibModal.open({

--- a/app/views/clients/viewclient.html
+++ b/app/views/clients/viewclient.html
@@ -14,6 +14,17 @@
 			<button class="btn btn-primary" ng-click="delete()">{{'label.button.confirm' | translate}}</button>
 		</div>
 	</script>
+	<script type="text/ng-template" id="deletesig.html">
+		<div class="modal-header silver">
+			<h3 class="bolder">{{'label.button.deletesig' | translate}}</h3>
+		</div>
+		<div class="modal-body">
+			<api-validate></api-validate>
+			<span ng-show="docId == -1">{{'label.noClientSignature' | translate}}</span> <br> <br>
+			<button class="btn btn-warning" ng-click="cancel()">{{'label.button.cancel' | translate}}</button>
+			<button class="btn btn-primary" ng-show="docId != -1" ng-click="delete()">{{'label.button.confirm' | translate}}</button>
+		</div>
+	</script>
 	<script type="text/ng-template" id="photo-dialog.html">
 		<div class="modal-header silver">
 			<img ng-src="{{largeImage}}" alt="Avatar">
@@ -195,6 +206,10 @@
 										</li>
 										<li>
 											<a data-ng-click="uploadSig()" has-permission='CREATE_CLIENTIMAGE'>{{'label.button.uploadsig'
+												| translate}}</a>
+										</li>
+										<li>
+											<a data-ng-click="deleteSig()" has-permission='DELETE_CLIENTIMAGE'>{{'label.button.deletesig'
 												| translate}}</a>
 										</li>
 										<li data-ng-show="clientAccounts.savingsAccounts">


### PR DESCRIPTION
## Description
This PR is a fix for https://issues.apache.org/jira/browse/FINERACT-544.  Although the functionality to delete signatures is available on the backend, it is not present in the community app.  This PR adds the functionality to delete a client's signature from the viewclient page.

## Related issues and discussion
https://issues.apache.org/jira/browse/FINERACT-544

## Screenshots, if any
Dropdown menu:
![screenshot 13](https://user-images.githubusercontent.com/23515048/34177258-d85c728c-e4b7-11e7-86cd-1b9d70e228b9.jpeg)

Delete signature modal (when signature exists):
![screenshot 14](https://user-images.githubusercontent.com/23515048/34177273-e93e1dc6-e4b7-11e7-8f8d-05615b91fc79.jpeg)

Modal when no signature exists:
![screenshot 15](https://user-images.githubusercontent.com/23515048/34177299-fc69747c-e4b7-11e7-874d-cdb24bc02050.jpeg)
