### PR TITLE
Fixed ability to upload client identity documents

### DIFF
--- a/app/scripts/controllers/client/UploadClientIdentifierDocumentController.js
+++ b/app/scripts/controllers/client/UploadClientIdentifierDocumentController.js
@@ -3,15 +3,11 @@
         UploadClientIdentifierDocumentController: function (scope, location, routeParams, API_VERSION, Upload, $rootScope) {
             scope.clientId = routeParams.clientId;
             scope.resourceId = routeParams.resourceId;
-            scope.onFileSelect = function ($files) {
-                scope.file = $files[0];
-            };
-
-            scope.submit = function () {
+            scope.uploadPic = function (file) {
                 Upload.upload({
                     url:  $rootScope.hostUrl + API_VERSION + '/client_identifiers/' + scope.resourceId + '/documents',
                     data: scope.formData,
-                    file: scope.file
+                    file: file
                 }).then(function (data) {
                         // to fix IE not refreshing the model
                         if (!scope.$$phase) {

--- a/app/views/clients/addclientidentifierdocument.html
+++ b/app/views/clients/addclientidentifierdocument.html
@@ -30,7 +30,7 @@
                         class="required">*</span></label>
 
                 <div class="col-sm-3">
-                    <input type="file" id="file" nv-file-select="onFileSelect($files)">
+                    <input type="file" ng-model="picFile" id="file" ngf-select>
                 </div>
             </div>
 
@@ -38,7 +38,7 @@
                 <a id="cancel" href="#/viewclient/{{clientId}}">
                     <button type="reset" class="btn btn-default">{{'label.button.cancel' | translate}}</button>
                 </a>
-                <button id="save" type="submit" ng-disabled="!clientidentifierform.$valid" class="btn btn-primary" has-permission='CREATE_CLIENTIDENTIFIER'>
+                <button id="save" type="submit" ng-click="uploadPic(picFile)" ng-disabled="!clientidentifierform.$valid" class="btn btn-primary" has-permission='CREATE_CLIENTIDENTIFIER'>
                     {{'label.button.save' | translate}}
                 </button>
             </div>

--- a/test/spec/controllers/client/UploadClientIdentifierDocumentController_spec.js
+++ b/test/spec/controllers/client/UploadClientIdentifierDocumentController_spec.js
@@ -23,31 +23,25 @@ describe('UploadClientIdentifierDocumentController', function() {
     ); 
   }));
 
-  it('should put the select file in the scope', function(){
-    var file = {name: 'some file'}
-    this.scope.onFileSelect ([file]);
-    expect(this.scope.file).toBe(file);
-  });
-
-  describe('on submit', function(){
+  describe('on uploadPic', function(){
     var url;
     beforeEach(function(){
       url = this.$rootScope.hostUrl + this.API_VERSION + '/client_identifiers/' + this.routeParams.resourceId + '/documents';
-      this.scope.file = {name: 'some file'}  
+      picFile = {name: 'some file'}  
       this.scope.formData = 'formData';
     });
 
     it('should call the upload service', function(){ 
-      this.scope.submit();  
+      this.scope.uploadPic(picFile);  
       expect(this.upload.upload).toHaveBeenCalledWith({
         url: url,
         data: this.scope.formData,
-        file: this.scope.file,
+        file: picFile,
       });
     });
 
     it('should change the location after file has been uploaded', function(){
-      this.scope.submit();
+      this.scope.uploadPic();
       deferedUpload.resolve('data');
       this.scope.$digest();
       expect(this.location.path).toHaveBeenCalledWith('/viewclient/' + this.routeParams.clientId);


### PR DESCRIPTION
## Description
This PR fixes the functionality to upload client identity documents to a client's profile.  Prior to this fix, the server would respond with error code 500.  I found that this was occurring because the image file was not being uploaded properly.  My conjecture was that this was caused by an update to the ng-file-upload directive.  Anyways, this fix just makes the file upload without error.

## Related issues and discussion
This addresses issue #2656 
## Screenshots, if any

Client documents are able to be uploaded (and downloaded again!).  Post request is now working, so server responds with 200:
<img width="927" alt="screenie" src="https://user-images.githubusercontent.com/23515048/34281200-d693329a-e671-11e7-92a9-63a54da1fa9d.png">


