### PR TITLE
Fix #2683 - Tooltip for red loan account should be "Active in Bad Standing"

### DIFF
--- a/app/scripts/controllers/client/ViewClientController.js
+++ b/app/scripts/controllers/client/ViewClientController.js
@@ -453,6 +453,13 @@
             };
             resourceFactory.clientAccountResource.get({clientId: routeParams.id}, function (data) {
                 scope.clientAccounts = data;
+                if(data.loanAccounts){
+                    for(var i in data.loanAccounts){
+                        if(data.loanAccounts[i].status.value == "Active" && data.loanAccounts[i].inArrears){
+                            scope.clientAccounts.loanAccounts[i].status.value = "Active in Bad Standing"
+                        }
+                    }
+                }
                 if (data.savingsAccounts) {
                     for (var i in data.savingsAccounts) {
                         if (data.savingsAccounts[i].status.value == "Active") {


### PR DESCRIPTION
## Description
Made the fix that @edcable suggested in issue #2683.  Before, red and green loan accounts would both have the tooltip "Active".  Now, the red ones instead have a tooltip saying "Active in Bad Standing".

## Related issues and discussion
#2683 

## Screenshots
![activeinbadstanding](https://user-images.githubusercontent.com/23515048/34317867-6a50a9e4-e76d-11e7-9a6b-5f6cab8698b0.jpg)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
