### PR TITLE
Fix #2680 - Tooltip for Submitted and Pending Approval Should Display above Nav Bar

### DIFF
--- a/app/styles-dev/main/components/_layout.scss
+++ b/app/styles-dev/main/components/_layout.scss
@@ -42,7 +42,7 @@ $sidebar-hover-width : 240px;
     position: fixed;
     top: 52px;
     bottom: 0;
-    z-index: 9999;
+    z-index: 999;
 
     @include flex(1 100%);
     @include order(0);

--- a/app/styles/styles.css
+++ b/app/styles/styles.css
@@ -7906,7 +7906,7 @@ span.required {
     position: fixed;
     top: 52px;
     bottom: 0;
-    z-index: 9999;
+    z-index: 999;
     -webkit-box-flex: 1 100%;
     -moz-box-flex: 1 100%;
     -webkit-flex: 1 100%;


### PR DESCRIPTION
## Description
Z-index of the "tooltip" class is changed so as to now be just above that of the side navbar.  Tooltips now display above nav bar.

## Related issues and discussion
#2680 

## Screenshots, if any
![zindexstuff](https://user-images.githubusercontent.com/23515048/34318067-c527d702-e772-11e7-8178-bb6779d535ac.jpg)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
