### PR TITLE
Fix #2677 - Delete/Upload Sig in View Modal

### DIFF
--- a/app/scripts/controllers/client/ViewClientController.js
+++ b/app/scripts/controllers/client/ViewClientController.js
@@ -846,24 +846,29 @@
                 $scope.cancel = function () {
                     $uibModalInstance.dismiss('cancel');
                 };
+                $scope.uploadSig = function () {
+                    $uibModalInstance.dismiss('cancel');
+                    scope.uploadSig();
+                };
             };
+
             var ViewLargerClientSignature = function($scope,$uibModalInstance){
                 var loadSignature = function(){
                     http({
                         method: 'GET',
                         url: $rootScope.hostUrl + API_VERSION + '/clients/' + routeParams.id + '/documents'
                     }).then(function (docsData) {
-                        var docId = -1;
+                        $scope.docId = -1;
                         for (var i = 0; i < docsData.data.length; ++i) {
                             if (docsData.data[i].name == 'clientSignature') {
-                                docId = docsData.data[i].id;
-                                scope.signature_url = $rootScope.hostUrl + API_VERSION + '/clients/' + routeParams.id + '/documents/' + docId + '/attachment?tenantIdentifier=' + $rootScope.tenantIdentifier;
+                                $scope.docId = docsData.data[i].id;
+                                scope.signature_url = $rootScope.hostUrl + API_VERSION + '/clients/' + routeParams.id + '/documents/' + $scope.docId + '/attachment?tenantIdentifier=' + $rootScope.tenantIdentifier;
                             }
                         }
                         if (scope.signature_url != null) {
                             http({
                                 method: 'GET',
-                                url: $rootScope.hostUrl + API_VERSION + '/clients/' + routeParams.id + '/documents/' + docId + '/attachment?tenantIdentifier=' + $rootScope.tenantIdentifier
+                                url: $rootScope.hostUrl + API_VERSION + '/clients/' + routeParams.id + '/documents/' + $scope.docId + '/attachment?tenantIdentifier=' + $rootScope.tenantIdentifier
                             }).then(function (docsData) {
                                 $scope.largeImage = scope.signature_url;
                             });
@@ -871,6 +876,14 @@
                     });
                 };
                 loadSignature();
+                $scope.deleteSig = function () {
+                    $uibModalInstance.dismiss('cancel');
+                    scope.deleteSig();
+                };
+                $scope.uploadSig = function () {
+                    $uibModalInstance.dismiss('cancel');
+                    scope.uploadSig();
+                };
                 $scope.cancel = function () {
                     $uibModalInstance.dismiss('cancel');
                 };

--- a/app/views/clients/viewclient.html
+++ b/app/views/clients/viewclient.html
@@ -39,6 +39,8 @@
 		</div>
 		<div class="modal-body ">
 			<button class="btn btn-warning" ng-click="cancel()">{{'label.button.cancel' | translate}}</button>
+			<button class="btn btn-danger" ng-click="deleteSig()" has-permission='DELETE_CLIENTIMAGE'><i class="fa fa-trash-o" aria-hidden="true"></i>{{'label.button.delete' | translate}}</button>
+			<button class="btn btn-primary" ng-click="uploadSig()" has-permission='CREATE_CLIENTIMAGE'><i class="fa fa-upload" aria-hidden="true"></i>{{'label.button.upload' | translate}}</button>
 		</div>
 	</script>
 	<script type="text/ng-template" id="clientWithoutSignature.html">
@@ -46,7 +48,8 @@
 			<h3 class="bolder">{{'label.noClientSignature' | translate}}</h3>
 		</div>
 		<div class="modal-body ">
-			<button class="btn btn-warning" ng-click="cancel()">{{'label.button.ok' | translate}}</button>
+			<button class="btn btn-warning" ng-click="cancel()">{{'label.button.cancel' | translate}}</button>
+			<button class="btn btn-primary" ng-click="uploadSig()" has-permission='CREATE_CLIENTIMAGE'><i class="fa fa-upload" aria-hidden="true"></i>{{'label.button.upload' | translate}}</button>
 		</div>
 	</script>
 


### PR DESCRIPTION
## Description
This PR adds functionality to delete or reupload a client signature within the view signature modal, improving the community app's ease of use.

## Related issues and discussion
#2677 

## Screenshots, if any
When no signature exists:
![screenshot 26](https://user-images.githubusercontent.com/23515048/34376501-dbc2d828-eaa0-11e7-98a9-adbcbc41193d.jpeg)

When signature exists:
![screenshot 27](https://user-images.githubusercontent.com/23515048/34376507-e0d022c6-eaa0-11e7-87de-847b3511f1a1.jpeg)


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
