### PR TITLE
Fix #2655 - Client address issues

### DIFF
--- a/app/global-translations/locale-en.json
+++ b/app/global-translations/locale-en.json
@@ -2593,7 +2593,6 @@
   "#Inputs": "..",
   "label.input.addressType": "Address Type",
   "label.input.clientIdNameOffice": "Client Id-Name-Office",
-  "label.input.street": "Street",
   "label.input.addressline1": "Address Line 1",
   "label.input.addressline2": "Address Line 2",
   "label.input.addressline3": "Address Line 3",

--- a/app/scripts/controllers/client/CreateClientController.js
+++ b/app/scripts/controllers/client/CreateClientController.js
@@ -321,10 +321,6 @@
                         {
                             temp.addressTypeId=scope.addressArray[i].addressTypeId;
                         }
-                        if(scope.addressArray[i].street)
-                        {
-                            temp.street=scope.addressArray[i].street;
-                        }
                         if(scope.addressArray[i].addressLine1)
                         {
                             temp.addressLine1=scope.addressArray[i].addressLine1;

--- a/app/scripts/controllers/configurations/EditAddressController.js
+++ b/app/scripts/controllers/configurations/EditAddressController.js
@@ -61,10 +61,6 @@
                     {
                         if(data[i].addressId==addressId)
                         {
-                            if(data[i].street&&$scope.street)
-                            {
-                                $scope.formData.street=data[i].street;
-                            }
                             if(data[i].addressLine1&&$scope.addressLine1)
                             {
                                 $scope.formData.addressLine1=data[i].addressLine1;

--- a/app/views/administration/AddressForm.html
+++ b/app/views/administration/AddressForm.html
@@ -19,16 +19,6 @@
             </div>
 
 
-            <div class="form-group" ng-show="street">
-                <label class="control-label col-sm-2" for="street">{{ 'label.input.street' | translate }}</label>
-
-                <div class="col-sm-3">
-                    <input type="text" id="street" name="street"  ng-model="formData.street"  class="form-control">
-                </div>
-
-            </div>
-
-
             <div class="form-group" ng-show="addressLine1">
                 <label class="control-label col-sm-2" for="addressline1">{{ 'label.input.addressline1' | translate }}</label>
 
@@ -101,7 +91,7 @@
 
             </div>
 
-            <div class="form-group" ng-show="country">
+            <div class="form-group" ng-show="countryId">
                 <div class="control-label col-sm-2">
                     <label>{{ 'label.input.country' | translate }}</label>
                 </div>

--- a/app/views/administration/EditAddress.html
+++ b/app/views/administration/EditAddress.html
@@ -7,15 +7,6 @@
 
 
 
-            <div class="form-group" ng-show="street">
-                <label class="control-label col-sm-2" for="street">{{ 'label.input.street' | translate }}</label>
-
-                <div class="col-sm-3">
-                    <input type="text" id="street" name="street"  ng-model="formData.street"  class="form-control">
-                </div>
-
-            </div>
-
 
             <div class="form-group" ng-show="addressLine1">
                 <label class="control-label col-sm-2" for="addressline1">{{ 'label.input.addressline1' | translate }}</label>
@@ -147,7 +138,7 @@
                 </button>-->
 
                 <button id="edit"  ng-click="updateaddress()" class="btn btn-primary">{{
-                    'label.button.edit' | translate }}
+                    'label.button.submit' | translate }}
                 </button>
 
             </div>

--- a/app/views/clients/createclient.html
+++ b/app/views/clients/createclient.html
@@ -442,17 +442,6 @@
                            </div>
                            <a ng-click="removeAddress($index)" uib-tooltip="{{'label.remove.row' | translate}}"><i class="fa fa-times"></i></a>
                         </div>
-                        <div class="form-group" ng-show="street">
-                           <div class="control-label col-sm-2">
-                              <label>{{ 'label.input.street' | translate }}<span class="required">*</span></label>
-                           </div>
-                           <div class="col-sm-3">
-                              <input type="text" name="street"  ng-model="addressArray[$index].street"  class="form-control" required late-validate/>
-                           </div>
-                           <div class = "col-sm-2">
-                              <form-validate valattributeform="createclientform" valattribute="street"/>
-                           </div>
-                        </div>
                         <div class="form-group" ng-show="addressLine1">
                            <label class="control-label col-sm-2" >{{ 'label.input.addressline1' | translate }}</label>
                            <div class="col-sm-3">

--- a/app/views/clients/viewclient.html
+++ b/app/views/clients/viewclient.html
@@ -682,14 +682,6 @@
 							</tr>
 							</thead>
 							<tbody>
-							<tr ng-show="view.street">
-								<th >
-									{{'label.input.street' | translate }}
-								</th>
-								<td>
-									{{address.street}}
-								</td>
-							</tr>
 							<tr ng-show="view.addressLine1">
 								<th>
 									{{'label.input.addressline1' | translate }}


### PR DESCRIPTION
## Description
All changes that were made relate to the issues with creating and viewing a client's address. Below are the changes made:

1. "Street" field is removed from throughout because there is already Address line 1, 2, and 3 (street is redundant). However, this creates a problem because the back-end requires this field to be filled. Please remove this verification in the back-end before you merge this pull request.
2. Rename the "Edit" button to "Submit".
3. Show the "Country" dropdown when creating a client.

## Related issues
### #2655 

## Screenshots
![Viewing a client](https://user-images.githubusercontent.com/16819026/34424571-9fac175c-ebf2-11e7-96c6-bb45ee78705d.png)
The "Street" field is not shown when the client is viewed.

![Editing a client](https://user-images.githubusercontent.com/16819026/34424549-715fbf84-ebf2-11e7-8924-67ce89f9acc8.png)
The "Street" field is not shown when a client is created or edited. The "Edit" button has been changed to "Submit".

<hr>
Part of a task for Google Code-in 2017. 🥇 
