### PR TITLE
Fix #2530 - Make field in loan product/account optional

### DIFF
--- a/app/views/loans/newloanaccount.html
+++ b/app/views/loans/newloanaccount.html
@@ -342,8 +342,7 @@
                             </td>
                             <td colspan="2"
                                 ng-hide="response.uiDisplayConfigurations.loanAccount.isHiddenField.interestCalculationPeriodType == true || formData.interestCalculationPeriodType == 0">
-                                <label>{{ 'label.input.allowpartialperiodinterestcalcualtion' | translate }}&nbsp;<span
-                                        class="required">*</span>: &nbsp;</label>
+                                <label>{{ 'label.input.allowpartialperiodinterestcalcualtion' | translate }}&nbsp;</label>
                                 <label class="checkbox control-label">
                                     <input id="allowPartialPeriodInterestCalcualtion" type="checkbox"
                                            ng-model="formData.allowPartialPeriodInterestCalcualtion"

--- a/app/views/products/createloanproduct.html
+++ b/app/views/products/createloanproduct.html
@@ -597,8 +597,7 @@
                 </div>
                 <label class="control-label col-sm-3 col-sm-offset-1"
                        ng-show="formData.interestCalculationPeriodType == 1">{{
-                    'label.input.allowpartialperiodinterestcalcualtion' | translate }}<span
-                            class="required">*</span>
+                    'label.input.allowpartialperiodinterestcalcualtion' | translate }}
                     <i class="fa fa-question-circle "
                        uib-tooltip="{'label.tooltip.allowpartialperiodinterestcalcualtion' | translate}}"
                        tooltip-append-to-body="true"></i>


### PR DESCRIPTION
## Description
The field **"Calculate interest for exact days in partial period"** is not mandatory anymore. The red asterisk is also not displayed. 
The files `newloanaccount.html` and `createloanproduct.html` were changed. 
The files `editloanaccount.html` and `editloanproduct.html` did not need to be changed because the field is already optional in those files.


## Related issues
### #2530

## Screenshots
![screenshot](https://user-images.githubusercontent.com/16819026/34445997-c613d444-eca5-11e7-80a0-af6c7eaaf802.PNG)
There is no asterisk on the field anymore, indicating that it is not required.

<hr>
Part of a task for Google Code-in 2017. 🥇 

