### PR TITLE
Fix for #2439 - Can not Undo Approval Share Account after adding Note

### DIFF
--- a/app/scripts/controllers/shares/ShareAccountActionsController.js
+++ b/app/scripts/controllers/shares/ShareAccountActionsController.js
@@ -34,7 +34,7 @@
                 case "undoapproval":
                     scope.title = 'label.heading.undoapproveshareaccount';
                     scope.showDateField = false;
-                    scope.showNoteField = true;
+                    scope.showNoteField = false;
                     scope.taskPermissionName = 'UNDOAPPROVAL_SHAREACCOUNT';
                     break;
                 case "activate":


### PR DESCRIPTION
## Description
Currently, there is no support on the Fineract API side to add a note for the undo approval of a loan account function.  So, I removed the notes functionality on the front-end. 

## Related issues and discussion
#2439 

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
