### PR TITLE
Fixed for #2718 - SMS Campaign typos

### DIFF
--- a/app/global-translations/locale-en.json
+++ b/app/global-translations/locale-en.json
@@ -747,6 +747,8 @@
   "#Headings": "..",
   "label.heading.addmember": "Add Member",
   "label.heading.addrole": "Add Role",
+  "label.heading.viewsmscampaign": "View SMS Campaign",
+  "label.heading.editsmscampaign": "Edit SMS Campaign",
   "label.heading.repeatdetails": "Repeat Details",
   "label.heading.meetingdetails": "Meeting Details",
   "label.heading.creategroup": "Create Group",

--- a/app/views/organization/smscampaigns/editsmscampaign.html
+++ b/app/views/organization/smscampaigns/editsmscampaign.html
@@ -8,7 +8,7 @@
     <div class="card">
         <div class="content">
             <div class="toolbar">
-                <h3>Edit SMS Campain</h3>
+                <h3>{{'label.heading.editsmscampaign' | translate}}</h3>
             </div>
             <br>
             <form name="editsmsform" novalidate="" class="form-horizontal " rc-submit="submit()">

--- a/app/views/organization/smscampaigns/smscampaigns.html
+++ b/app/views/organization/smscampaigns/smscampaigns.html
@@ -7,7 +7,7 @@
     <div class="card">
         <div class="content">
             <div class="toolbar">
-                <h4>SMScampaings</h4>
+                <h4>{{'label.anchor.smscampaings' | translate}}</h4>
             </div>
             <br>
             <div class="row">

--- a/app/views/organization/smscampaigns/viewsmscampaign.html
+++ b/app/views/organization/smscampaigns/viewsmscampaign.html
@@ -10,7 +10,7 @@
     <div class="card">
         <div class="content" >
             <div class="toolbar">
-                <h3>View SMS Campain</h3>
+                <h3>{{'label.heading.viewsmscampaign' | translate}}</h3>
             </div>
             <br/>
             <uib-tabset tabset-name="smsCampaignTabset">


### PR DESCRIPTION
## Description
@edcable noticed some typos in the SMS campaign part of the web app.  This fix resolves those typos.

## Related issues and discussion
#2718

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.

  