### PR TITLE
Fix #2723 - Corrected the column names in view closed loans

### DIFF
--- a/app/views/clients/viewclient.html
+++ b/app/views/clients/viewclient.html
@@ -372,6 +372,9 @@
 										<tr class="graybg">
 											<th>{{'label.heading.accnum' | translate}}</th>
 											<th>{{'label.heading.loanaccount' | translate}}</th>
+                                                                                       <th>{{'label.heading.loanamount' | translate}}</th>
+											<th>{{'label.heading.outstandingamount' | translate}}</th>
+                                                                                       <th>{{'label.heading.dueamount' | translate}}</th>
 											<th class="center">{{'label.heading.type' | translate}}</th>
 											<th>{{'label.heading.closedate' | translate}}</th>
 										</tr>
@@ -384,7 +387,7 @@
 											<td class="pointer" data-ng-click="routeToLoan(loanaccount.id)">{{loanaccount.productName}}</td>
 											<td class="pointer" data-ng-click="routeToLoan(loanaccount.id)">{{loanaccount.originalLoan|number}}</td>
 											<td class="pointer" data-ng-click="routeToLoan(loanaccount.id)">{{loanaccount.loanBalance|number}}</td>
-											<td class="pointer" data-ng-click="routeToLoan(loanaccount.id)">{{loanaccount.amountPaid|number}}</td>
+                                                                                       <td class="pointer" data-ng-click="routeToLoan(loanaccount.id)">{{loanaccount.amountPaid|number}}</td>
 											<td class="pointer center" data-ng-click="routeToLoan(loanaccount.id)" ng-if="loanaccount.loanType.value == 'Individual'">
 												<i uib-tooltip="{{loanaccount.loanType.value}}" class="fa fa-user fa fa-large"></i>
 											</td>


### PR DESCRIPTION
## Description
Corrected the column names as per the data in ```view closed loan```

## Related issues and discussion
#2723 

## Screenshots, if any
![screenshot at 2018-01-05 11 51 00](https://user-images.githubusercontent.com/21126132/34597798-1b090e74-f20f-11e7-98f8-1ee8657251fa.png)
