### PR TITLE
Fix #2181 - Not Allowing to Approve in 'view checker inbox' to create a new datatable

### DIFF
--- a/app/scripts/services/ResourceFactoryProvider.js
+++ b/app/scripts/services/ResourceFactoryProvider.js
@@ -461,7 +461,8 @@
                     }),
                     checkerInboxResource: defineResource(apiVer + "/makercheckers/:templateResource", {templateResource: '@templateResource'}, {
                         get: {method: 'GET', params: {}},
-                        search: {method: 'GET', params: {}, isArray: true}
+                        search: {method: 'GET', params: {}, isArray: true},
+                        save: {method: 'POST', params: {command : '@command'}}
                     }),
                     officeToGLAccountMappingResource: defineResource(apiVer + "/financialactivityaccounts/:mappingId", {mappingId: '@mappingId'}, {
                         get: {method: 'GET', params: {mappingId: '@mappingId'}},


### PR DESCRIPTION
## Description
I looked through the code and found that the controller calls checkerinboxresource.save, which didn't previously exist.  I added it into the resourcefactoryprovider.

## Related issues and discussion
#2181 

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
