### PR TITLE
Fix #2668 - Restrict width of Product and Fund

### DIFF
--- a/app/styles-dev/main/components/_report.scss
+++ b/app/styles-dev/main/components/_report.scss
@@ -52,6 +52,10 @@
 }
 .width36{
   width: 36%;
+  #productId, #fundId{
+    max-width: 300px;
+    text-overflow: ellipsis;
+  }
 }
 .width40{
   width: 40%;

--- a/app/styles/styles.css
+++ b/app/styles/styles.css
@@ -8174,6 +8174,9 @@ div.chosen-container.chosen-container-single {
 
 .width36 {
   width: 36%; }
+  .width36 #productId, .width36 #fundId {
+    max-width: 300px;
+    text-overflow: ellipsis; }
 
 .width40 {
   width: 40%; }
@@ -8290,3 +8293,5 @@ hr.marginbottom {
   padding-left: 20px; }
 .container td:last-child {
   padding-right: 20px; }
+
+/*# sourceMappingURL=styles.css.map */


### PR DESCRIPTION
## Description
Gave product and fund select fields in new loan application a max width because they were going out of box due to large options.

## Related issues and discussion
#2668 #2712 

## Screenshots, if any
![1](https://user-images.githubusercontent.com/20224346/34643788-920d8468-f350-11e7-9ac9-30719323536b.png)


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
