### PR TITLE
Fix #2760 - Fixed the popover to show description in Create loan Products

### DIFF
--- a/app/views/products/createloanproduct.html
+++ b/app/views/products/createloanproduct.html
@@ -584,7 +584,7 @@
                 <label class="control-label col-sm-2">{{ 'label.input.interestcalculationperiod' | translate }}<span
                         class="required">*</span>
                     <i class="fa fa-question-circle "
-                       uib-tooltip="{'label.tooltip.interestcalculationperiod' | translate}}"
+                       uib-tooltip="{{'label.tooltip.interestcalculationperiod' | translate}}"
                        tooltip-append-to-body="true"></i>
                 </label>
 
@@ -599,7 +599,7 @@
                        ng-show="formData.interestCalculationPeriodType == 1">{{
                     'label.input.allowpartialperiodinterestcalcualtion' | translate }}
                     <i class="fa fa-question-circle "
-                       uib-tooltip="{'label.tooltip.allowpartialperiodinterestcalcualtion' | translate}}"
+                       uib-tooltip="{{'label.tooltip.allowpartialperiodinterestcalcualtion' | translate}}"
                        tooltip-append-to-body="true"></i>
                 </label>
 
@@ -614,7 +614,7 @@
             <div class="form-group">
                 <label class="control-label col-sm-2">{{ 'label.input.repaymentstrategy' | translate }}<span
                         class="required">*</span>
-                    <i class="fa fa-question-circle " uib-tooltip="{'label.tooltip.repaymentstrategy' | translate}}"
+                    <i class="fa fa-question-circle " uib-tooltip="{{'label.tooltip.repaymentstrategy' | translate}}"
                        tooltip-append-to-body="true"></i>
                 </label>
 
@@ -629,7 +629,7 @@
             <div class="form-group">
                 <br>
                 <label class="control-label col-sm-2">{{ 'label.input.grace' | translate }}
-                    <i class="fa fa-question-circle " uib-tooltip="{'label.tooltip.moratorium' | translate}}"
+                    <i class="fa fa-question-circle " uib-tooltip="{{'label.tooltip.moratorium' | translate}}"
                        tooltip-append-to-body="true"></i>
                 </label>
 
@@ -645,7 +645,7 @@
             </div>
             <div class="form-group">
                 <label class="control-label col-sm-2">{{ 'label.input.interestfreeperiod' | translate }}
-                    <i class="fa fa-question-circle " uib-tooltip="{'label.tooltip.interestfreeperiod' | translate}}"
+                    <i class="fa fa-question-circle " uib-tooltip="{{'label.tooltip.interestfreeperiod' | translate}}"
                        tooltip-append-to-body="true"></i>
                 </label>
 
@@ -654,7 +654,7 @@
                            ng-model="formData.graceOnInterestCharged">
                 </div>
                 <label class="control-label col-sm-2 col-sm-offset-2">{{ 'label.input.arearstolerance' | translate }}
-                    <i class="fa fa-question-circle " uib-tooltip="{'label.tooltip.arearstolerance' | translate}}"
+                    <i class="fa fa-question-circle " uib-tooltip="{{'label.tooltip.arearstolerance' | translate}}"
                        tooltip-append-to-body="true"></i>
                 </label>
 
@@ -666,7 +666,7 @@
             <div class="form-group">
                 <label class="control-label col-sm-2">{{'label.input.daysinyears' | translate }}<span
                         class="required">*</span>
-                    <i class="fa fa-question-circle " uib-tooltip="{'label.tooltip.daysinyear' | translate}}"
+                    <i class="fa fa-question-circle " uib-tooltip="{{'label.tooltip.daysinyear' | translate}}"
                        tooltip-append-to-body="true"></i>
                 </label>
 
@@ -678,7 +678,7 @@
                 </div>
                 <label class="control-label col-sm-2 col-sm-offset-2">{{ 'label.input.daysinmonth' |
                     translate }}<span class="required">*</span>
-                    <i class="fa fa-question-circle " uib-tooltip="{'label.tooltip.daysinmonth' | translate}}"
+                    <i class="fa fa-question-circle " uib-tooltip="{{'label.tooltip.daysinmonth' | translate}}"
                        tooltip-append-to-body="true"></i>
                 </label>
 
@@ -703,7 +703,7 @@
             <div class="form-group">
                 <label class="control-label col-sm-4">{{ 'label.input.no.of.overdue.days.to.move.loan.into.arrears'
                     | translate }}
-                    <i class="fa fa-question-circle " uib-tooltip="{'label.tooltip.numberofdays' | translate}}"
+                    <i class="fa fa-question-circle " uib-tooltip="{{'label.tooltip.numberofdays' | translate}}"
                        tooltip-append-to-body="true"></i>
                 </label>
 
@@ -716,7 +716,7 @@
             <div class="form-group">
                 <label class="control-label col-sm-4">{{ 'label.input.no.of.overdue.days.to.change.loan.into.npa'
                     | translate }}
-                    <i class="fa fa-question-circle " uib-tooltip="{'label.tooltip.maxNumberofDays' | translate}}"
+                    <i class="fa fa-question-circle " uib-tooltip="{{'label.tooltip.maxNumberofDays' | translate}}"
                        tooltip-append-to-body="true"></i>
                 </label>
 
@@ -753,7 +753,7 @@
                     <input type="checkbox" name="name1" ng-model="formData.allowVariableInstallments"/>
                     {{'label.input.isvariableinstallmentsallowed' | translate}}
                     <i class="fa fa-question-circle "
-                       uib-tooltip="{'label.tooltip.loanproduct.variableinstallments' | translate}}"
+                       uib-tooltip="{{'label.tooltip.loanproduct.variableinstallments' | translate}}"
                        tooltip-append-to-body="true"></i>
                 </div>
             </div>
@@ -801,7 +801,7 @@
                 <label class="control-label col-sm-2">{{'label.input.preclose.interest.calculation.strategy'
                     | translate }}<span class="required">*</span>
                     <i class="fa fa-question-circle "
-                       uib-tooltip="{'label.tooltip.preclosureinterestcalculationstrategy' | translate}}"
+                       uib-tooltip="{{'label.tooltip.preclosureinterestcalculationstrategy' | translate}}"
                        tooltip-append-to-body="true"></i>
                 </label>
 
@@ -814,7 +814,7 @@
                 </div>
                 <label class="control-label col-sm-2 col-sm-offset-2">{{'label.input.interest.recalculation.reschdule.strategy'
                     | translate }}<span class="required">*</span>
-                    <i class="fa fa-question-circle " uib-tooltip="{'label.tooltip.advancepayments' | translate}}"
+                    <i class="fa fa-question-circle " uib-tooltip="{{'label.tooltip.advancepayments' | translate}}"
                        tooltip-append-to-body="true"></i>
                 </label>
 
@@ -830,7 +830,7 @@
             <div class="form-group" data-ng-show="formData.isInterestRecalculationEnabled">
                 <label class="control-label col-sm-2">{{'label.input.interest.recalculation.compounding.method'
                     | translate }}<span class="required">*</span>
-                    <i class="fa fa-question-circle " uib-tooltip="{'label.tooltip.interestrecalculation' | translate}}"
+                    <i class="fa fa-question-circle " uib-tooltip="{{'label.tooltip.interestrecalculation' | translate}}"
                        tooltip-append-to-body="true"></i>
                 </label>
 
@@ -848,7 +848,7 @@
                 <label class="control-label col-sm-2">{{'label.input.frequency.for.compounding'
                     | translate }}<span class="required">*</span>
                     <i class="fa fa-question-circle "
-                       uib-tooltip="{'label.tooltip.frequencytocompounding' | translate}}"
+                       uib-tooltip="{{'label.tooltip.frequencytocompounding' | translate}}"
                        tooltip-append-to-body="true"></i>
                 </label>
 
@@ -896,7 +896,7 @@
                 <label class="control-label col-sm-2">{{'label.input.frequenc.interval.for.compounding'
                     | translate }}<span class="required">*</span>
                     <i class="fa fa-question-circle "
-                       uib-tooltip="{'label.tooltip.frequencycompoundinginterval' | translate}}"
+                       uib-tooltip="{{'label.tooltip.frequencycompoundinginterval' | translate}}"
                        tooltip-append-to-body="true"></i>
                 </label>
 
@@ -912,7 +912,7 @@
                 <label class="control-label col-sm-2">{{'label.input.frequency.for.recalculte.outstanding.principal'
                     | translate }}<span class="required">*</span>
                     <i class="fa fa-question-circle "
-                       uib-tooltip="{'label.tooltip.frequencytorecalculate' | translate}}"
+                       uib-tooltip="{{'label.tooltip.frequencytorecalculate' | translate}}"
                        tooltip-append-to-body="true"></i>
                 </label>
 
@@ -957,7 +957,7 @@
                  data-ng-show="formData.isInterestRecalculationEnabled && formData.recalculationRestFrequencyType != 1">
                 <label class="control-label col-sm-2">{{'label.input.frequenc.interval.for.recalculte.outstanding.principal'
                     | translate }}<span class="required">*</span>
-                    <i class="fa fa-question-circle " uib-tooltip="{'label.tooltip.frequencyInterval' | translate}}"
+                    <i class="fa fa-question-circle " uib-tooltip="{{'label.tooltip.frequencyInterval' | translate}}"
                        tooltip-append-to-body="true"></i>
                 </label>
 
@@ -1021,7 +1021,7 @@
             <hr>
             <div class="form-group">
                 <label class="control-label col-sm-2">{{ 'label.input.multidisburseloan' | translate }}
-                    <i class="fa fa-question-circle " uib-tooltip="{'label.tooltip.isMultiDisburseLoan' | translate}}"
+                    <i class="fa fa-question-circle " uib-tooltip="{{'label.tooltip.isMultiDisburseLoan' | translate}}"
                        tooltip-append-to-body="true"></i>
                 </label>
 
@@ -1033,7 +1033,7 @@
             </div>
             <div class="form-group" ng-show="formData.multiDisburseLoan">
                 <label class="control-label col-sm-2">{{ 'label.input.maxtranchecount' | translate }}
-                    <i class="fa fa-question-circle " uib-tooltip="{'label.tooltip.maxtranchecount' | translate}}"
+                    <i class="fa fa-question-circle " uib-tooltip="{{'label.tooltip.maxtranchecount' | translate}}"
                        tooltip-append-to-body="true"></i>
                 </label>
 
@@ -1044,7 +1044,7 @@
                 <label class="control-label col-sm-3 col-sm-offset-1">{{ 'label.input.outstandingloanbalance' |
                     translate }}
                     <i class="fa fa-question-circle "
-                       uib-tooltip="{'label.tooltip.maxAllowedOutstandingBalance' | translate}}"
+                       uib-tooltip="{{'label.tooltip.maxAllowedOutstandingBalance' | translate}}"
                        tooltip-append-to-body="true"></i>
                 </label>
 


### PR DESCRIPTION
## Description
Fixed the tooltip to show the description in "Create loan products " settings part.

## Related issues and discussion
#2760 

## Screenshots, if any
![screenshot at 2018-01-07 11 11 58](https://user-images.githubusercontent.com/21126132/34646985-0dcf1dc8-f39c-11e7-8dba-1afa14c37195.png)
![screenshot at 2018-01-07 11 11 53](https://user-images.githubusercontent.com/21126132/34646986-1adb4e9c-f39c-11e7-88a8-1a2f1e05fb0a.png)
![screenshot at 2018-01-07 11 11 49](https://user-images.githubusercontent.com/21126132/34646989-22b7ae8a-f39c-11e7-9c07-27d8b65a5e5f.png)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
