### PR TITLE
Fix #2766 Validation and Popover issue in Floating Rate Section

### DIFF
--- a/app/views/products/floatingrates/CreateFloatingRate.html
+++ b/app/views/products/floatingrates/CreateFloatingRate.html
@@ -9,12 +9,13 @@
         <api-validate></api-validate>
         <fieldset>
             <div class="form-group">
-                <div class="col-sm-2">
+                <div class="col-sm-3">
                     <label class="control-label" for="name">{{'label.input.floatingratename' | translate}}<span
                             class="required">*</span> &nbsp;
-                        <i class="fa fa-question-circle" uib-tooltip="{{'label.tooltip.floatingratename' | translate}}"></i>
+                        <i class="fa fa-question-circle"
+                        uib-tooltip="{{'label.tooltip.floatingratename' | translate}}"
+                        tooltip-append-to-body="true"></i>
                     </label>
-
                 </div>
                 <div class="col-sm-2">
                     <input name="name" type="text" id="name" ng-model="formData.name" class="form-control"
@@ -26,11 +27,12 @@
                 <div class="col-sm-3">
                   <input type="checkbox" name="name1" ng-model="formData.isBaseLendingRate"/>
                   <label class="control-label" >{{'label.input.isbaselendingrate' | translate}}
-                  &nbsp;<i class="fa fa-question-circle" uib-tooltip="{{'label.tooltip.isBaseLendingRate' | translate}}"></i>
+                  &nbsp;    <i class="fa fa-question-circle" uib-tooltip="{{'label.tooltip.isBaseLendingRate' | translate}}"
+                        tooltip-append-to-body="true"></i>
                   </label>
                 </div>
 
-                <div class="col-sm-3">
+                <div class="col-sm-2">
                     <input type="checkbox" name="name1" ng-model="formData.isActive"/>
                     <label class="control-label" >{{'label.input.active' | translate}}
                     &nbsp;<i class="fa fa-question-circle" uib-tooltip="{{'label.tooltip.isActive' | translate}}"></i>
@@ -41,9 +43,10 @@
             <hr/>
 
             <div class="form-group">
-                <div class="col-sm-2">
+                <div class="col-sm-3">
                     <label class="bolder" >{{'label.heading.rateperiods' | translate}}
-                        &nbsp;<i class="fa fa-question-circle" uib-tooltip="{{'label.tooltip.rateperiods' | translate}}"></i>
+                        &nbsp;<i class="fa fa-question-circle" uib-tooltip="{{'label.tooltip.rateperiods' | translate}}"
+                         tooltip-append-to-body="true"></i>
                     </label>
                 </div>
                 <div class="col-sm-1">
@@ -54,8 +57,10 @@
             <table class="table width80" ng-show="formData.ratePeriods.length>0" >
                 <tr class="graybg" class="width50">
                     <th>{{'label.heading.fromdate' | translate}}
+                        <span class="required">*</span>
                         &nbsp;<i class="fa fa-question-circle" uib-tooltip="{{'label.tooltip.floatingfromdate' | translate}}"></i></th>
                     <th>{{'label.heading.interestrate' | translate}}
+                        <span class="required">*</span>
                         &nbsp;<i class="fa fa-question-circle" uib-tooltip="{{'label.tooltip.floatigannualinterest' | translate}}"></i></th>
                     <th>{{'label.heading.isdifferentaialtobaselendingrate' | translate}}
                         &nbsp;<i class="fa fa-question-circle" uib-tooltip="{{'label.tooltip.floatingisdifferential' | translate}}"></i></th>
@@ -86,7 +91,7 @@
                     </td>
                    </tr>
             </table>
-            <div class="col-md-offset-3">
+            <div class="col-md-offset-4">
                 <a id="cancel" href="#/floatingrates">
                     <button type="reset" class="btn btn-default">{{'label.button.cancel' | translate}}</button>
                 </a>

--- a/app/views/products/floatingrates/EditFloatingRate.html
+++ b/app/views/products/floatingrates/EditFloatingRate.html
@@ -9,7 +9,7 @@
         <api-validate></api-validate>
         <fieldset>
             <div class="form-group">
-                <div class="col-sm-2">
+                <div class="col-sm-3">
                     <label class="control-label" for="name">{{'label.input.floatingratename' | translate}}<span
                             class="required">*</span>
                         &nbsp;
@@ -27,11 +27,12 @@
                 <div class="col-sm-3">
                     <input type="checkbox" name="name1" ng-model="formData.isBaseLendingRate"/>
                     <label class="control-label" >{{'label.input.isbaselendingrate' | translate}}
-                        &nbsp;<i class="fa fa-question-circle" uib-tooltip="{{'label.tooltip.isBaseLendingRate' | translate}}"></i>
+                        &nbsp;<i class="fa fa-question-circle" uib-tooltip="{{'label.tooltip.isBaseLendingRate' | translate}}"
+                        tooltip-append-to-body="true"></i>
                     </label>
                 </div>
 
-                <div class="col-sm-3">
+                <div class="col-sm-2">
                     <input type="checkbox" name="name1" ng-model="formData.isActive"/>
                     <label class="control-label" >{{'label.input.active' | translate}}
                         &nbsp;<i class="fa fa-question-circle" uib-tooltip="{{'label.tooltip.isActive' | translate}}"></i>
@@ -41,7 +42,7 @@
             </div>
             <hr/>
             <div class="form-group">
-                <div class="col-sm-2">
+                <div class="col-sm-3">
                     <label class="control-label bolder" >{{'label.heading.rateperiods' | translate}}
                         &nbsp;<i class="fa fa-question-circle" uib-tooltip="{{'label.tooltip.rateperiods' | translate}}"></i>
                     </label>
@@ -55,8 +56,10 @@
             <table class="table width80" ng-show="formData.ratePeriods.length>0">
                 <tr class="graybg">
                     <th>{{'label.heading.fromdate' | translate}}
+                        <span class="required">*</span>
                         &nbsp;<i class="fa fa-question-circle" uib-tooltip="{{'label.tooltip.floatingfromdate' | translate}}"></i></th>
                     <th>{{'label.heading.interestrate' | translate}}
+                        <span class="required">*</span>
                         &nbsp;<i class="fa fa-question-circle" uib-tooltip="{{'label.tooltip.floatigannualinterest' | translate}}"></i></th>
                     <th>{{'label.heading.isdifferentaialtobaselendingrate' | translate}}
                         &nbsp;<i class="fa fa-question-circle" uib-tooltip="{{'label.tooltip.floatingisdifferential' | translate}}"></i></th>
@@ -66,7 +69,7 @@
                 <tr ng-repeat="rateperiod in formData.ratePeriods">
                     <td>
                         <ng-form name="fromDate{{$index}}">
-                            <input type="text" id="fromDate1" name="fromDate1" datepicker-pop="dd MMMM yyyy"
+                            <input type="text" id="fromDate1{{$index}}" name="fromDate1" datepicker-pop="dd MMMM yyyy"
                                    ng-model="rateperiod.fromDate" is-open="opened" min="'2000-01-01'" max="restrictDate"
                                    class="form-control" required/>
                             <span class="error" ng-show="visitValidation&&fromDate{{$index}}.fromDate1.$error.required">{{ 'label.requirefield' | translate }}</span>
@@ -74,7 +77,7 @@
                     </td>
                     <td>
                         <ng-form name="interestRate{{$index}}">
-                            <input id="interestRate1" name="interestRate1" class="form-control" type="text"
+                            <input id="interestRate1{{$index}}" name="interestRate1" class="form-control" type="text"
                                    ng-model="rateperiod.interestRate" number-format required/>
                             <span class="error" ng-show="visitValidation&&interestRate{{$index}}.interestRate1.$error.required">{{ 'label.requirefield' | translate }}</span>
                         </ng-form>
@@ -90,7 +93,7 @@
                 </tr>
             </table>
 
-            <div class="col-md-offset-3">
+            <div class="col-md-offset-4">
                 <a id="cancel" href="#/floatingrates">
                     <button type="reset" class="btn btn-default">{{'label.button.cancel' | translate}}</button>
                 </a>

--- a/app/views/products/floatingrates/ViewFloatingRate.html
+++ b/app/views/products/floatingrates/ViewFloatingRate.html
@@ -16,7 +16,7 @@
                     <label class="control-label">{{'label.input.floatingratename' | translate}}:&nbsp;</label>
                     <label class="control-label">{{name}}</label>
                 </div>
-                <div class="col-sm-2">
+                <div class="col-sm-3">
                     <input type="checkbox" name="name1" ng-model="isBaseLendingRate" disabled/>
                     <label class="control-label" >{{'label.input.isbaselendingrate' | translate}}</label>
                 </div>


### PR DESCRIPTION
## Description
1) Asterisks added for fields From Date and Interest Rate which are required fields
2) Question mark help icons for popovers are properly aligned for Floating Rate Name and Floating Rate Periods
3) Popovers are visible on hovering mouse over the question mark icons of Floating Rate Name, Is Base Lending Rate
4) On creation of a floating rate, label for Is base lending rate is properly aligned in the review page

Similar issues were resolved for sections creating and editing the floating rate.

## Related issues and discussion
#2766 

## Screenshots, if any
![screenshot 75](https://user-images.githubusercontent.com/16948598/34648654-85c96780-f3c3-11e7-8800-840e6d951a17.png)
![screenshot 76](https://user-images.githubusercontent.com/16948598/34648655-860f5150-f3c3-11e7-8cf5-9c8982e5eb5e.png)
![screenshot 77](https://user-images.githubusercontent.com/16948598/34648653-857fe75e-f3c3-11e7-8d7f-837acc8e375c.png)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.

  