### PR TITLE
Fix #2769 Breadcrumb links to non existing page in Add Charge(Client)

### DIFF
--- a/app/scripts/controllers/client/AddNewClientChargeController.js
+++ b/app/scripts/controllers/client/AddNewClientChargeController.js
@@ -1,8 +1,8 @@
 (function (module) {
     mifosX.controllers = _.extend(module, {
         AddNewClientChargeController: function (scope, resourceFactory, location, routeParams, dateFilter) {
+            scope.clientId = routeParams.id;
             scope.offices = [];
-            scope.cancelRoute = routeParams.id;
             scope.date = {};
 
             resourceFactory.clientChargesResource.get({clientId: routeParams.id, resourceType: 'template'}, function (data) {

--- a/app/views/clients/addnewclientcharge.html
+++ b/app/views/clients/addnewclientcharge.html
@@ -1,10 +1,10 @@
-<div class="content-container">
+<div class="content-container" ng-controller="AddNewClientChargeController">
     <ul class="breadcrumb">
         <li><a ng-href="#/viewclient/{{clientId}}">{{'label.anchor.viewclient' | translate}}</a></li>
         <li class="active">{{ 'label.button.addcharge' | translate }}</li>
     </ul>
 
-<form name="clientchargeform" novalidate="" class="card form-horizontal" ng-controller="AddNewClientChargeController"
+<form name="clientchargeform" novalidate="" class="card form-horizontal"
       rc-submit="submit()">
     <api-validate></api-validate>
     <fieldset class="content">
@@ -67,7 +67,7 @@
         </div>
 
         <div class="col-md-offset-3">
-            <a id="cancel" href="#/viewclient/{{cancelRoute}}" class="btn btn-default">{{'label.button.cancel' |
+            <a id="cancel" href="#/viewclient/{{clientId}}" class="btn btn-default">{{'label.button.cancel' |
                 translate}}</a>
             <button id="save" type="submit" class="btn btn-primary" has-permission='CREATE_CLIENTCHARGE'>{{'label.button.save' | translate}}</button>
         </div>


### PR DESCRIPTION
## Description
The breadcrumb link goes back to the client's page (viewclient/[id]), ex: /viewclient/42 on click (while adding a charge for a client) now, instead of giving a 404 error.

## Related issues and discussion
#2769 

## Screenshots, if any
![screenshot 78](https://user-images.githubusercontent.com/16948598/34648822-be18b79a-f3c7-11e7-96b1-e43caec9e52e.png)
![screenshot 79](https://user-images.githubusercontent.com/16948598/34648823-be6280b4-f3c7-11e7-80de-356c3196274c.png)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
