### PR TITLE
Fix #2764 - Fixed next and previous buttons in create group form

### DIFF
--- a/app/views/groups/creategroup.html
+++ b/app/views/groups/creategroup.html
@@ -132,10 +132,11 @@
 								<button id="save" type="submit" class="btn btn-primary" has-permission='CREATE_GROUP' wz-next>{{'label.button.save' | translate}}</button>
 							</div>
 							<hr>
-							<button class="btn btn-default pull-left" wz-previous><i class="fa fa-arrow-left"></i>&nbsp;&nbsp;Previous
+                                                       <button ng-show="datatables.length > 0" class="btn btn-default pull-left" wz-previous><i class="fa fa-arrow-left"></i>&nbsp;&nbsp;Previous
 							</button>
-							<button class="btn btn-default pull-right" wz-next>Next&nbsp;&nbsp;<i
+							<button ng-show="datatables.length > 0" class="btn btn-default pull-right" wz-next>Next&nbsp;&nbsp;<i
 									class="fa fa-arrow-right"></i></button>
+
 						</fieldset>
 					</form>
 			</wz-step>


### PR DESCRIPTION
## Description
Removed redundant/non-functioning buttons i.e., ```Previous``` and ```Next``` from the create group form.

## Related issues and discussion
#2764 

## Screenshots, if any
![screenshot at 2018-01-07 20 16 15](https://user-images.githubusercontent.com/21126132/34650454-a6476448-f3e7-11e7-80ea-b810ed52a2e4.png)

