### PR TITLE
Fixed #2651 - Unnecessary step after "Reject Transfer" of a client

### DIFF
--- a/app/scripts/controllers/client/ClientActionsController.js
+++ b/app/scripts/controllers/client/ClientActionsController.js
@@ -383,8 +383,11 @@
                     delete this.formData.locale;
                     delete this.formData.dateFormat;
                     resourceFactory.clientResource.save({clientId: routeParams.id, command: 'rejectTransfer'}, this.formData, function (data) {
-                        location.path('/viewclient/' + data.clientId);
+                        resourceFactory.clientResource.save({clientId: routeParams.id, command: 'withdrawTransfer'}, {} ,function (data) {
+                            location.path('/viewclient/' + data.clientId);
+                        });
                     });
+                    
                 }
                 if (scope.action == "undotransfer") {
                     delete this.formData.locale;


### PR DESCRIPTION
## Description
Currently, after a client's transfer is rejected, they are not placed back into an active state.  As suggested, this fix places a client back into an active state in their original (pre-transfer) office.

## Related issues and discussion
#2651 

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
