### PR TITLE
Fix #2789 Validation message overlap with dropdown in Create entity data table checks

### DIFF
--- a/app/views/organization/entitydatatablechecks/entitydatatablechecks.html
+++ b/app/views/organization/entitydatatablechecks/entitydatatablechecks.html
@@ -33,18 +33,18 @@
     <dir-pagination-controls boundary-links="true" template-url="bower_components/angular-utils-pagination/dirPagination.tpl.html" on-page-change="getResultsPage(newPageNumber)"></dir-pagination-controls>
 
     <script type="text/ng-template" id="createentitydatatablecheck.html">
-        <form name="createdatatablecheckform" novalidate="">
+        <form name="createdatatablecheckform" novalidate="" class="form-horizontal">
             <api-validate></api-validate>
             <div class="modal-dialog">
                 <div class="modal-header silver">
                     <h3 class="bolder">{{'label.heading.createdatatablecheck' | translate}}</h3>
                 </div>
                 <br/>
-                <div>
+                <div class="modal-body">
                     <div class="form-group">
                         <label class="control-label col-sm-3">{{'label.input.entity' | translate}}<span
                                 class="required">*</span></label>
-                        <div class="col-sm-3">
+                        <div class="col-sm-5">
                             <select id="checkEntity"
                                     name="checkEntity"
                                     chosen="entities"
@@ -60,12 +60,10 @@
                             <form-validate valattributeform="createdatatablecheckform" valattribute="checkEntity"/>
                         </div>
                     </div>
-                    <br/>
-                    <br/>
                     <div class="form-group">
                         <label class="control-label col-sm-3">{{'label.input.status' | translate}}<span
                                 class="required">*</span></label>
-                        <div class="col-sm-3">
+                        <div class="col-sm-5">
                             <select id="checkStatus"
                                     name="checkStatus"
                                     chosen="statusList"
@@ -81,12 +79,10 @@
                             <form-validate valattributeform="createdatatablecheckform" valattribute="checkStatus"/>
                         </div>
                     </div>
-                    <br/>
-                    <br/>
                     <div class="form-group">
                         <label class="control-label col-sm-3">{{'label.input.datatable' | translate}}<span
                                 class="required">*</span></label>
-                        <div class="col-sm-3">
+                        <div class="col-sm-5">
                             <select id="checkDatatable"
                                     name="checkDatatable"
                                     chosen="filteredDatatables"
@@ -102,11 +98,10 @@
                             <form-validate valattributeform="createdatatablecheckform" valattribute="checkDatatable"/>
                         </div>
                     </div>
-                    <br/>
-                    <br/>
                     <div class="form-group" ng-if="checkForm.entity == 'm_loan' || checkForm.entity == 'm_savings_account'">
-                        <label class="control-label col-sm-3">{{'label.input.product' | translate}}</label>
-                        <div class="col-sm-3">
+                        <label class="control-label col-sm-3">{{'label.input.product' | translate}}<span
+                        class="required">*</span></label>
+                        <div class="col-sm-5">
                             <select id="checkProduct"
                                     name="checkProduct"
                                     chosen="products"
@@ -132,9 +127,6 @@
                             <input id="systemDefinedCheckbox" name="systemDefinedCheckbox" type="checkbox" ng-model="$parent.checkForm.systemDefined">
                         </div>
                     </div>-->
-                    <br/>
-                    <br/>
-                    <br/>
                     <div class="col-md-offset-4">
                         <button class="btn btn-warning" ng-click="cancel()">{{'label.button.cancel' | translate}}</button>
                         <button class="btn btn-primary" ng-click="create()">{{'label.button.create' | translate}}</button>


### PR DESCRIPTION
## Description
The validation messages no longer overlap with the dropdowns. The form fields have been added to a div containing modal-body class so the dropdowns take the width of their parent divs and do not overlap with the validation text.

## Related issues and discussion
#2789  

## Screenshots, if any
![screenshot 85](https://user-images.githubusercontent.com/16948598/34679928-7c85fe72-f4bd-11e7-88f2-b9ad28d5834a.png)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
