### PR TITLE
Fix #2795 Allowing user to skip over steps by clicking directly on progress bar with proper indication of validation

### DIFF
--- a/app/scripts/modules/angular-wizard.js
+++ b/app/scripts/modules/angular-wizard.js
@@ -24,7 +24,7 @@ angular.module("wizard.html", []).run(["$templateCache", function($templateCache
            // "      <div ng-repeat=\"step in steps\" ng-class=\"{'active':step.title == selectedStep.title, default: !step.completed && !step.selected, 'current': step.selected && !step.completed, 'done': step.completed && !step.selected, 'editing': step.selected && step.completed}\">\n" +
                 "<h3 ng-hide='getEnabledSteps().length > 1'>{{steps[0].title || steps[0].wzTitle}}</h3>"+
                 " <ul class=\"progress-indicator\" ng-show='getEnabledSteps().length > 1'>"+
-            "        <li ng-repeat=\"step in getEnabledSteps()\" ng-click=\"goTo(step)\" ng-class=\"{'progress-current':step.selected,'progress-todo': " +
+            "        <li ng-repeat=\"step in getEnabledSteps()\" ng-click=\"goTo(step, true)\" ng-class=\"{'progress-current':step.selected,'progress-todo': " +
                 "!step.completed && !step.selected, " +
                 "'progress-done': step.completed && !step.selected , 'progress-danger': step.danger && !step.selected}\">" +
                 "<span class='bubble'></span><i class='fa fa-check' ng-show='step.completed && !step.selected'></i>"+
@@ -69,6 +69,9 @@ angular.module('mgo-angular-wizard').directive('wzStep', function() {
                 $scope.title = $scope.wzTitle;
             });
             $scope.title = $scope.wzTitle;
+            if($element.find('.form-horizontal')[0].attributes['ng-submit']) {
+                $scope.formController = $element.find('.form-horizontal').controller("form");
+            }
             wizard.addStep($scope);
             $scope.$on('$destroy', function(){
                 wizard.removeStep($scope);
@@ -209,7 +212,7 @@ angular.module('mgo-angular-wizard').directive('wizard', function() {
                 return stepIdx(step) + 1;
             };
 
-            $scope.goTo = function(step) {
+            $scope.goTo = function(step, onClick) {
                 //if this is the first time the wizard is loading it bi-passes step validation
                 if(firstRun){
                     //deselect all steps so you can set fresh below
@@ -234,6 +237,11 @@ angular.module('mgo-angular-wizard').directive('wizard', function() {
                     } else if ($scope.currentStepNumber() === 0){
                         thisStep = 0;
                     }
+                    var formController = $scope.getEnabledSteps()[thisStep].formController;
+                    if(onClick && formController) {
+                        WizardHandler.wizard().checkValid(formController, onClick);
+                    }
+
                     //$log.log('steps[thisStep] Data: ', $scope.getEnabledSteps()[thisStep].canexit);
                     $q.all([canExitStep($scope.getEnabledSteps()[thisStep], step), canEnterStep(step)]).then(function(data) {
                         if(data[0] && data[1]){
@@ -367,20 +375,20 @@ angular.module('mgo-angular-wizard').directive('wizard', function() {
                 return $scope.currentStepNumber();
             };
 
-            this.checkValid = function(form){
+            this.checkValid = function(form, onClick){
                 if(form.$valid){
                     $scope.selectedStep.danger = false;
-                    this.next();
+                    this.next(undefined, onClick);
                 }
                 else{
                     
                     this.next(function(){
                         return $scope.selectedStep.danger = true;
-                    });
+                    }, onClick);
                 }
             }
             //method used for next button within step
-            this.next = function(callback) {
+            this.next = function(callback, onClick) {
                 var enabledSteps = $scope.getEnabledSteps();
                 //setting variable equal to step  you were on when next() was invoked
                 var index = stepIdx($scope.selectedStep);
@@ -391,7 +399,9 @@ angular.module('mgo-angular-wizard').directive('wizard', function() {
                             this.finish();
                         } else {
                             //invoking goTo() with step number next in line
-                            $scope.goTo(enabledSteps[index + 1]);
+                            if(!onClick) {
+                                $scope.goTo(enabledSteps[index + 1]);
+                            }
                         }
                     } else {
                         return;
@@ -412,7 +422,9 @@ angular.module('mgo-angular-wizard').directive('wizard', function() {
                     this.finish();
                 } else {
                     //invoking goTo() with step number next in line
-                    $scope.goTo(enabledSteps[index + 1]);
+                    if(!onClick) {
+                        $scope.goTo(enabledSteps[index + 1]);
+                    }
                 }
 
             };


### PR DESCRIPTION
## Description
The directive wizard being used as a progress bar was modified to indicate proper validation of data when the user directly clicks on the progress bar and might skip over seps.

## Related issues and discussion
#2795 

## Screenshots, if any
![screenshot 162](https://user-images.githubusercontent.com/16948598/34947088-1031f9a2-fa2f-11e7-8408-0ca43c5ddbf0.png)
![screenshot 155](https://user-images.githubusercontent.com/16948598/34947089-10825d8e-fa2f-11e7-9350-f2ffe124c0a6.png)
![screenshot 156](https://user-images.githubusercontent.com/16948598/34947090-10d18ba2-fa2f-11e7-980f-6acd1667f8eb.png)
![screenshot 158](https://user-images.githubusercontent.com/16948598/34947091-113eba56-fa2f-11e7-9392-6528b07dedba.png)
![screenshot 160](https://user-images.githubusercontent.com/16948598/34947092-11d7a8ec-fa2f-11e7-94db-a6a891034ddb.png)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
