### PR TITLE
Fix #2808 - Removed "charged payment by" field from edit charges

### DIFF
--- a/app/scripts/controllers/product/EditChargeController.js
+++ b/app/scripts/controllers/product/EditChargeController.js
@@ -31,6 +31,7 @@
                     scope.addfeefrequency = false;
                     scope.showGLAccount = false;
                     scope.showPenalty = false ;
+                    scope.flag = true;
                 }else {
                     scope.flag = true;
                     scope.template.chargeCalculationTypeOptions = data.clientChargeCalculationTypeOptions;


### PR DESCRIPTION
## Description
Removed the ```charged payment by``` field from Edit Charges.

## Related issues and discussion
#2808 

## Screenshots, if any
![screenshot at 2018-01-12 20 36 50](https://user-images.githubusercontent.com/21126132/34881024-57264600-f7d8-11e7-84ca-603a76f8c99f.png)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
