### PR TITLE
Fix #2824 Incorrect format of date in Fund Mapping

### DIFF
--- a/app/views/search/advsearch.html
+++ b/app/views/search/advsearch.html
@@ -52,14 +52,14 @@
 								</select>
 				            </div>
 				            <label  ng-show="showDateFields" class="col-sm-1 control-label">{{"label.input.between" | translate}}</label>
-				            <div class="col-sm-4">
+				            <div class="col-sm-6">
 				                <div class="row">
 				                    <div class="col-sm-4">
-				                        <input ng-show="showDateFields" type="text" datepicker-pop="yyyy-MM-dd" ng-model="formData.loanfromdate" is-open="opened" min="minDate" max="'2020-06-22'" placeholder="{{ 'label.input.fromdate' | translate }}" class="input-small form-control">
+				                        <input ng-show="showDateFields" type="text" datepicker-pop="dd MMMM yyyy" ng-model="formData.loanfromdate" is-open="opened" min="minDate" max="'2020-06-22'" placeholder="{{ 'label.input.fromdate' | translate }}" class="input-small form-control">
 				                    </div>
 				                    <label  class="col-sm-1 control-label">{{"label.and" | translate}}</label>
 				                    <div class="col-sm-4">
-							            <input ng-show="showDateFields" type="text" datepicker-pop="yyyy-MM-dd" ng-model="formData.loantodate" is-open="opened1" min="minDate" max="'2020-06-22'" placeholder="{{ 'label.input.todate' | translate }}" class="input-small form-control">
+							            <input ng-show="showDateFields" type="text" datepicker-pop="dd MMMM yyyy" ng-model="formData.loantodate" is-open="opened1" min="minDate" max="'2020-06-22'" placeholder="{{ 'label.input.todate' | translate }}" class="input-small form-control">
 							        </div>
 							    </div>
 				            </div>
@@ -80,7 +80,7 @@
 								</select>
 				            </div>
 				            <label  ng-show="formData.includeOutStandingAmountPercentage" class="col-sm-1 control-label">{{formData.outStandingAmountPercentageCondition}}</label>
-				            <div class="col-sm-4" ng-show="formData.includeOutStandingAmountPercentage">
+				            <div class="col-sm-6" ng-show="formData.includeOutStandingAmountPercentage">
 				                <span ng-hide="formData.outStandingAmountPercentageCondition == 'between'" class="col-sm-6">
 									<input type="text" ng-model="formData.outStandingAmountPercentage" class="input-small form-control">
 								</span>
@@ -113,7 +113,7 @@
 								</select>
 				            </div>
 				            <label  ng-show="formData.includeOutstandingAmount" class="col-sm-1 control-label">{{formData.outstandingAmountCondition}}</label>
-				            <div class="col-sm-4" ng-show="formData.includeOutstandingAmount">
+				            <div class="col-sm-6" ng-show="formData.includeOutstandingAmount">
 				                <span ng-hide="formData.outstandingAmountCondition == 'between'" class="col-sm-6">
 									<input type="text" ng-model="formData.outstandingAmount" class="input-small form-control">
 								</span>


### PR DESCRIPTION
## Description
Initial date format provided in fund mapping date picker was changed to the date format being used globally. (dd MMMM yyyy)

## Related issues and discussion
#2824 

## Screenshots, if any
![screenshot 169](https://user-images.githubusercontent.com/16948598/35049330-a24a1a1c-fbc5-11e7-9a48-57d8ba4a5d81.png)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
