### PR TITLE
Fix #2825 Changing Date Format in Settings does not update Date Format of Date Pickers in the app

### DIFF
--- a/app/scripts/modules/datepicker.js
+++ b/app/scripts/modules/datepicker.js
@@ -389,7 +389,7 @@ angular.module('modified.datepicker', ['strap.position'])
                 link: function (originalScope, element, attrs, ngModel) {
 
                     var closeOnDateSelection = angular.isDefined(attrs.closeOnDateSelection) ? scope.$eval(attrs.closeOnDateSelection) : datepickerPopConfig.closeOnDateSelection;
-                    var dateFormat = attrs.datepickerPop || datepickerPopConfig.dateFormat;
+                    var dateFormat = originalScope.df || attrs.datepickerPop || datepickerPopConfig.dateFormat;
 
                     // create a child scope for the datepicker directive so we are not polluting original scope
                     var scope = originalScope.$new();


### PR DESCRIPTION
## Description
The date format specified in settings was provided as the first preference of date format to be chosen for the date picker.

## Related issues and discussion
#2825 

## Screenshots, if any
![screenshot 170](https://user-images.githubusercontent.com/16948598/35050294-766b49c2-fbc8-11e7-97a9-024ee8cc444f.png)
![screenshot 171](https://user-images.githubusercontent.com/16948598/35050292-761561d8-fbc8-11e7-8bf4-48f0e167e59d.png)
![screenshot 173](https://user-images.githubusercontent.com/16948598/35050299-7d33cb26-fbc8-11e7-9490-5717bb19ead9.png)
![screenshot 172](https://user-images.githubusercontent.com/16948598/35050300-7e2583b2-fbc8-11e7-8560-e3b6287c7acf.png)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
