### PR TITLE
Fix #2839 Redundant Breadcrumb Link Removed from Currency Configuration

### DIFF
--- a/app/views/organization/currencyconfig.html
+++ b/app/views/organization/currencyconfig.html
@@ -5,14 +5,8 @@
         </ul>
     <div class="card">
         <div class="content">
-            <div ng-show="hideview">
-                <ul class="breadcrumb">
-                    <li><a href="#/organization">{{'label.anchor.organization' | translate}}</a></li>
-                    <li class="active">{{'label.anchor.editcurrencyconfig' | translate}}</li>
-                </ul>
-            </div>
             <div class="pull-right">
-                <a ng-click="hideview = !hideview" class="btn btn-primary" has-permission='UPDATE_CURRENCY' id="edit-currency"><i
+                <a ng-click="hideview = !hideview" ng-hide="hideview" class="btn btn-primary" has-permission='UPDATE_CURRENCY' id="edit-currency"><i
                         class="fa fa-plus "></i>{{'label.button.addedit' | translate}}</a>
             </div>
             <br>


### PR DESCRIPTION
## Description
The unnecessary redundant breadcrumb link being displayed while adding/editing currency configuration was removed. Also, the add/edit button is hidden on click because it is no longer required as a cancel and submit button show up.

## Related issues and discussion
#2839 

## Screenshots, if any
![screenshot 188](https://user-images.githubusercontent.com/16948598/35173868-0ea61c82-fd93-11e7-89a8-8fb3d168fb08.png)
![screenshot 189](https://user-images.githubusercontent.com/16948598/35173867-0e5883d2-fd93-11e7-8817-459954695aa4.png)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
