### PR TITLE
Fix #2841 Complete Data Showing Up in Share Products, Redundant Next/Previous Buttons Removed

### DIFF
--- a/app/scripts/controllers/product/ShareProductController.js
+++ b/app/scripts/controllers/product/ShareProductController.js
@@ -1,6 +1,6 @@
 (function (module) {
     mifosX.controllers = _.extend(module, {
-        ShareProductController: function (scope, paginatorService, resourceFactory, location) {
+        ShareProductController: function (scope, resourceFactory, location) {
             scope.shareproducts = [];
 
             scope.routeTo = function (id) {
@@ -18,21 +18,14 @@
                 scope.saveSC();
             };
 
-            var fetchFunction = function (offset, limit, callback) {
-                var params = {};
-                params.offset = offset;
-                params.limit = limit;
-                params.locale = scope.optlang.code;
-                params.dateFormat = scope.df;
-                scope.saveSC();
-                resourceFactory.shareProduct.getAll(params, callback) ;
-            };
-
-            paginatorService.currentOffset = 0 ;
-            scope.shareproducts = paginatorService.paginate(fetchFunction, 10);
+            scope.$broadcast('ShareProductDataLoadingStartEvent');
+            resourceFactory.shareProduct.getAll(function(data) {
+                scope.shareproducts = data;
+                scope.$broadcast('ShareProductDataLoadingCompleteEvent');
+            });
         }
     });
-    mifosX.ng.application.controller('ShareProductController', ['$scope', 'PaginatorService', 'ResourceFactory', '$location', mifosX.controllers.ShareProductController]).run(function ($log) {
+    mifosX.ng.application.controller('ShareProductController', ['$scope', 'ResourceFactory', '$location', mifosX.controllers.ShareProductController]).run(function ($log) {
         $log.info("ShareProductController initialized");
     });
 }(mifosX.controllers || {}));

--- a/app/views/products/shareproducts.html
+++ b/app/views/products/shareproducts.html
@@ -14,27 +14,19 @@
         </div>
         <table class="table">
         <thead>
-        <tr class="graybg">
-            <th>{{'label.heading.name' | translate}}</th>
-            <th>{{'label.heading.shortname' | translate}}</th>
-            <th>{{'label.heading.totalshares' | translate}}</th>
-        </tr>
+            <tr class="graybg">
+                <th>{{'label.heading.name' | translate}}</th>
+                <th>{{'label.heading.shortname' | translate}}</th>
+                <th>{{'label.heading.totalshares' | translate}}</th>
+            </tr>
         </thead>
         <tbody>
-        <tr class="pointer-main" ng-repeat="shareproduct in shareproducts.currentPageItems | orderBy:'name':reverse | filter:filterText">
-            <td class="pointer" data-ng-click="routeTo(shareproduct.id)">{{shareproduct.name}}</td>
-            <td class="pointer" data-ng-click="routeTo(shareproduct.id)">{{shareproduct.shortName}}</td>
-            <td class="pointer" data-ng-click="routeTo(shareproduct.id)">{{shareproduct.totalShares}}</td>
-        </tr>
+            <tr class="pointer-main" ng-repeat="shareproduct in shareproducts.pageItems | orderBy:'name':reverse | filter:filterText">
+                <td class="pointer" data-ng-click="routeTo(shareproduct.id)">{{shareproduct.name}}</td>
+                <td class="pointer" data-ng-click="routeTo(shareproduct.id)">{{shareproduct.shortName}}</td>
+                <td class="pointer" data-ng-click="routeTo(shareproduct.id)">{{shareproduct.totalShares}}</td>
+            </tr>
         </tbody>
         </table>
-
-        <ul class="pager">
-        <li class="previous"><a id="prev" ng-click="entries.previous()" href=""
-                                ng-disabled="!entries.hasPrevious()">&larr; {{'label.button.previous' |
-            translate}}</a></li>
-        <li class="next"><a id="next" ng-click="entries.next()" href="" ng-disabled="!entries.hasNext()">{{'label.button.next'
-            | translate}} </a></li>
-        </ul>
     </div>
 </div>    


### PR DESCRIPTION
## Description
The complete data is now showing up in share products and pagination has been removed as in other sections of products.

## Related issues and discussion
#2841 

## Screenshots, if any
![screenshot 191](https://user-images.githubusercontent.com/16948598/35181894-c4ce1750-fdf0-11e7-9aa9-7d501a9d87e1.png)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
