### PR TITLE
Fix #2847 - Added missing breadcrumb in attendance

### DIFF
--- a/app/scripts/controllers/centers/CenterAttendanceController.js
+++ b/app/scripts/controllers/centers/CenterAttendanceController.js
@@ -6,6 +6,7 @@
             scope.formData = {};
             scope.first = {};
             scope.first.date = new Date();
+            scope.centerId = routeParams.centerId;
             resourceFactory.centerResource.get({centerId: routeParams.centerId, associations: 'groupMembers,collectionMeetingCalendar'}, function (data) {
                 scope.center = data;
                 scope.meeting = data.collectionMeetingCalendar;

--- a/app/scripts/controllers/groups/GroupAttendanceController.js
+++ b/app/scripts/controllers/groups/GroupAttendanceController.js
@@ -5,10 +5,14 @@
             scope.first = {};
             scope.first.date = new Date();
             scope.formData = {};
+            scope.clientId = routeParams.clientId;
+            scope.groupId = routeParams.groupId;
 
             resourceFactory.groupResource.get({groupId: routeParams.groupId, associations: 'all'}, function (data) {
                 scope.group = data;
                 scope.meeting = data.collectionMeetingCalendar;
+                scope.groupName = scope.group.name;
+
             });
 
             resourceFactory.groupMeetingResource.getMeetingInfo({groupId: routeParams.groupId, templateSource: 'template', calenderId: routeParams.calendarId}, function (data) {

--- a/app/views/centers/centerattendance.html
+++ b/app/views/centers/centerattendance.html
@@ -1,5 +1,7 @@
 <div class="content-container" ng-controller="CenterAttendanceController">
     <ul class="breadcrumb">
+        <li><a href="#/centers">{{'label.anchor.centers' | translate}}</a></li>
+        <li><a href="#/viewcenter/{{centerId}}">{{center.name}}</a></li>
         <li class="active">attendance</li>
     </ul>
     <div class="card">

--- a/app/views/groups/groupattendance.html
+++ b/app/views/groups/groupattendance.html
@@ -1,4 +1,8 @@
 <div class="content-container" ng-controller="GroupAttendanceController">
+    <ul class="breadcrumb">
+        <li><a href="#/viewgroup/{{groupId}}">{{ groupName }}</a></li>
+        <li class="active">{{'label.heading.attendance' | translate}}</li>
+    </ul>
     <div class="card">
         <div class="content">
             <div class="toolbar">


### PR DESCRIPTION
## Description
Added the missing breadcrumb in the attendance(group and center).

## Related issues and discussion
#2847 

## Screenshots, if any
![screenshot at 2018-01-21 11 13 10](https://user-images.githubusercontent.com/21126132/35191284-0a539cda-fe9d-11e7-8ab4-b1e4cf8430fb.png)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
