### PR TITLE
Fix #2865 - Hide the next and previous and added cancel

### DIFF
--- a/app/scripts/controllers/shares/CreateShareAccountController.js
+++ b/app/scripts/controllers/shares/CreateShareAccountController.js
@@ -14,6 +14,7 @@
             if (scope.clientId) {
                 scope.inparams.clientId = scope.clientId
             }
+            scope.disabled = true;
             resourceFactory.shareAccountTemplateResource.get(scope.inparams, function (data) {
                 scope.products = data.productOptions;
                 scope.chargeOptions = data.chargeOptions;
@@ -30,6 +31,7 @@
                     scope.sharedetails = angular.copy(scope.formData);
                     scope.sharedetails.productName = scope.formValue(scope.products,scope.formData.productId,'id','name');
                 });
+                scope.disabled = false;
 
             };
 

--- a/app/views/loans/newloanaccount.html
+++ b/app/views/loans/newloanaccount.html
@@ -163,12 +163,13 @@
                         </tr>
                     </table>
                     <hr>
-                    <button class="btn btn-default pull-left" wz-previous>
-                        <i class="fa fa-arrow-left"></i>&nbsp;&nbsp;Previous
+                    <button class="btn btn-default pull-left" wz-previous disabled ng-hide="disabled"><i class="fa fa-arrow-left"></i>&nbsp;&nbsp;Previous
                     </button>
-                    <button class="btn btn-default pull-right" type="submit">Next&nbsp;&nbsp;
-                        <i class="fa fa-arrow-right"></i>
+                    <button class="btn btn-default pull-right" type="submit" ng-hide="disabled">Next&nbsp;&nbsp;<i class="fa fa-arrow-right"></i>
                     </button>
+                    <div class="col-sm-offset-6">
+                    <button class="btn btn-warning" ng-hide="!disabled" ng-click="cancel()">{{'label.button.cancel' | translate}}</button>
+                    </div>
                 </fieldset>
             </form>
         </wz-step>

--- a/app/views/savings/new_saving_account_application.html
+++ b/app/views/savings/new_saving_account_application.html
@@ -72,12 +72,13 @@
                         </tr>
                     </table>
                     <hr>
-                    <button class="btn btn-default pull-left" wz-previous disabled>
-                        <i class="fa fa-arrow-left"></i>&nbsp;&nbsp;Previous
+                    <button class="btn btn-default pull-left" wz-previous disabled ng-hide="disabled"><i class="fa fa-arrow-left"></i>&nbsp;&nbsp;Previous
                     </button>
-                    <button class="btn btn-default pull-right" type="submit">Next&nbsp;&nbsp;
-                        <i class="fa fa-arrow-right"></i>
+                    <button class="btn btn-default pull-right" type="submit" ng-hide="disabled">Next&nbsp;&nbsp;<i class="fa fa-arrow-right"></i>
                     </button>
+                    <div class="col-sm-offset-6">
+                    <button class="btn btn-warning" ng-hide="!disabled" ng-click="cancel()">{{'label.button.cancel' | translate}}</button>
+                    </div>
                 </fieldset>
             </form>
         </wz-step>

--- a/app/views/shares/createshareaccount.html
+++ b/app/views/shares/createshareaccount.html
@@ -56,12 +56,13 @@
                         </tr>
                     </table>
                     <hr>
-                    <button class="btn btn-default pull-left" wz-previous disabled>
-                        <i class="fa fa-arrow-left"></i>&nbsp;&nbsp;Previous
+                    <button class="btn btn-default pull-left" wz-previous disabled ng-hide="disabled"><i class="fa fa-arrow-left"></i>&nbsp;&nbsp;Previous
                     </button>
-                    <button class="btn btn-default pull-right" type="submit">Next&nbsp;&nbsp;
-                        <i class="fa fa-arrow-right"></i>
+                    <button class="btn btn-default pull-right" type="submit" ng-hide="disabled">Next&nbsp;&nbsp;<i class="fa fa-arrow-right"></i>
                     </button>
+                    <div class="col-sm-offset-6">
+                    <button class="btn btn-warning" ng-hide="!disabled" ng-click="cancel()">{{'label.button.cancel' | translate}}</button>
+                    </div>
                 </fieldset>
             </form>
         </wz-step>


### PR DESCRIPTION
## Description
HIde the next and previous buttons in the new application forms as listed and added a cancel button. Now the next and previous buttons are not shown until the product is selected.

## List:-
- [x] New loan account form
- [x] Saving Application
- [x] Shares Application

## Related issues and discussion
#2865 

## Screenshots, if any
![screenshot at 2018-02-05 08 19 33](https://user-images.githubusercontent.com/21126132/35786456-56f46856-0a4d-11e8-8512-b5138d489ae8.png)

Done same in other forms also.

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
