### PR TITLE
Fix#2883 - Made Greyish forms match up with new UI

### DIFF
--- a/app/global-translations/locale-en.json
+++ b/app/global-translations/locale-en.json
@@ -1239,6 +1239,7 @@
   "label.heading.guarantor": "Guarantor",
   "label.heading.createguarantor": "Create Guarantor",
   "label.heading.editloanaccount": "Edit Loan Account",
+  "label.heading.editloanapplication": "Edit Loan Application",
   "label.heading.meetingdetails": "Meeting Details",
   "label.heading.collaterals": "Collateral",
   "label.heading.value": "Value",

--- a/app/views/deposits/fixed/edit_account_application.html
+++ b/app/views/deposits/fixed/edit_account_application.html
@@ -9,7 +9,7 @@
             <div class="toolbar">
                 <h4>{{ 'label.heading.editfixeddepositapplication' | translate }}</h4>
             </div>
-            <form name="editfixeddepositaccountform" novalidate="" class="well form-inline" rc-submit="submit()">
+            <form name="editfixeddepositaccountform" novalidate="" class="form-inline" rc-submit="submit()">
         <fieldset>
         <table class="width100">
             <tr>

--- a/app/views/deposits/recurring/edit_account_application.html
+++ b/app/views/deposits/recurring/edit_account_application.html
@@ -7,7 +7,7 @@
     </ul>
 </div>
 <api-validate></api-validate>
-<form name="editrecurringdepositaccountform" novalidate="" class="well form-inline" rc-submit="submit()">
+<form name="editrecurringdepositaccountform" novalidate="" class="well form-inline card" rc-submit="submit()">
 <fieldset>
 <legend>{{ 'label.heading.editrecurringdepositapplication' | translate }}</legend>
 <table class="width100">

--- a/app/views/loans/editloanaccount.html
+++ b/app/views/loans/editloanaccount.html
@@ -7,8 +7,10 @@
         <li class="active">{{'label.anchor.modifyloanapplication' | translate}}</li>
     </ul>
 </div>
-<form name="editloanaccountform" novalidate="" class="well form-inline" rc-submit="submit()">
 <api-validate></api-validate>
+<form name="editloanaccountform" novalidate="" class="well form-inline card" rc-submit="submit()">
+<fieldset>
+<legend>{{ 'label.heading.editloanapplication' | translate }}</legend>
 <table class="width100">
     <tr>
         <td class="width14">
@@ -583,5 +585,6 @@
         translate}}
     </button>
 </div>
+</fieldset>
 </form>
 </div>

--- a/app/views/products/editloanproduct.html
+++ b/app/views/products/editloanproduct.html
@@ -447,8 +447,8 @@
                 ng-options="interestType.id as interestType.value for interestType in product.interestTypeOptions"
                 value="{{interestType.id}}"/>
     </div>
-    <label class="control-label col-sm-2">{{ 'label.input.isequalamortization' | translate }}</label> 
-    <div class="checkbox col-sm-1">               
+    <label class="control-label col-sm-2">{{ 'label.input.isequalamortization' | translate }}</label>
+    <div class="checkbox col-sm-1">
         <input type="checkbox" ng-model="formData.isEqualAmortization" ng-true-value="true"
                    ng-false-value="false">
     </div>


### PR DESCRIPTION
## Description
Made greyish forms match up with the new UI.

## Related issues and discussion
#2883 

## Screenshots, if any
**Before**
![screenshot at 2018-02-11 22 05 01](https://user-images.githubusercontent.com/21126132/36076503-f3cea896-0f82-11e8-9651-c2af9190c2f6.png)

**After**
![screenshot at 2018-02-11 23 25 29](https://user-images.githubusercontent.com/21126132/36076508-047ed4c2-0f83-11e8-9d20-b4fdda4a1683.png)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
