### PR TITLE
Fix #2889 Tooltip Label not being replaced with corresponding message

### DIFF
--- a/app/global-translations/locale-en.json
+++ b/app/global-translations/locale-en.json
@@ -1492,7 +1492,7 @@
   "label.tooltip.loanportfolio": "an Asset account that is debited during disbursement and credited during principal repayment/writeoff.",
   "label.tooltip.receivableinterest": "an Asset account that is used to accrue interest",
   "label.tooltip.receivablefees": "an Asset account that is used to accrue fees",
-  "label.tooltip.receivablepnalties": "an Asset account that is used to accrue penalties",
+  "label.tooltip.receivablepenalties": "an Asset account that is used to accrue penalties",
   "label.tooltip.transfersinsuspense": "an Asset account that is used a suspense account for tracking portfolios of loans under transfer.",
   "label.tooltip.incomefrominterest": "an Income account that is credited during interest payment.",
   "label.tooltip.incomefromfees": "an Income account that is credited during fee payment.",


### PR DESCRIPTION
## Description
The tooltip label is now being replaced by its corresponding text and displayed at Penalties Receivable (Accounting Section of Loan Products - Create/Edit)

## Related issues and discussion
#2889 

## Screenshots, if any
![screenshot 330](https://user-images.githubusercontent.com/16948598/36220946-7251ec80-11e2-11e8-940f-972072999e15.png)
![screenshot 331](https://user-images.githubusercontent.com/16948598/36220945-7197e484-11e2-11e8-9e39-d5c6c98fd326.png)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
