### PR TITLE
Fix #2900 - Fixed the transaction date

### DIFF
--- a/app/scripts/controllers/loanAccount/LoanAccountActionsController.js
+++ b/app/scripts/controllers/loanAccount/LoanAccountActionsController.js
@@ -208,7 +208,7 @@
                             scope.formData.paymentTypeId = data.paymentTypeOptions[0].id;
                         }
                         scope.formData.transactionAmount = data.amount;
-                        scope.formData[scope.modelName] = new Date(data.date) || new Date();
+                        scope.formData[scope.modelName] =  new Date();
                         if(data.penaltyChargesPortion>0){
                             scope.showPenaltyPortionDisplay = true;
                         }


### PR DESCRIPTION
## Description
Fixed the transaction date in repayment of approved loans. Earlier the default was a future date and on submitting the form it showed the error that future dates are not allowed. I made the default value as today's date.

## Related issues and discussion
#2900 

## Screenshots, if any

![screenshot at 2018-02-17 23 02 30](https://user-images.githubusercontent.com/21126132/36343813-c5d04360-1436-11e8-912a-eba55bdad861.png)
