### PR TITLE
Fixed #2907

### DIFF
--- a/app/global-translations/locale-en.json
+++ b/app/global-translations/locale-en.json
@@ -437,6 +437,7 @@
   "validation.msg.floatingrate.isDifferentialToBaseLendingRate.no.baselending.rate.defined": "Base Lending rate doesn't exists",
   "validation.msg.floatingrate.isDifferentialToBaseLendingRate.cannot.be.true.for.baselendingrate": "isDifferentialToBaseLendingRate cannot be true for floating rate marked as Base Lending Rate",
   "validation.msg.batch.jlg.no.clients.defined": "There is no clients selected for this request",
+  "validation.msg.future.date.entered": "Please enter a date less than today's date.",
   "#---------": "------------",
   "#Common loan/saving charges": "....",
   "#Headings": "..",

--- a/app/scripts/controllers/accounting/SearchTransactionController.js
+++ b/app/scripts/controllers/accounting/SearchTransactionController.js
@@ -6,6 +6,8 @@
                 {option: "Manual Entries", value: true},
                 {option: "System Entries", value: false}
             ];
+            scope.maxDate = new Date();
+            scope.dateError = false;
             scope.isCollapsed = true;
             scope.displayResults = false;
             scope.transactions = [];
@@ -116,10 +118,15 @@
                 scope.formData.savingsaccountId = null;
             };
 
-            scope.searchTransaction = function () {
-                scope.displayResults = true;
-                scope.transactions = paginatorService.paginate(fetchFunction, 14);
-                scope.isCollapsed = false;
+            scope.submit = function () {
+                if((this.date.first != undefined && this.date.first <= scope.maxDate) || (this.date.second != undefined && this.date.second <= scope.maxDate))
+                {
+                    scope.displayResults = true;
+                    scope.transactions = paginatorService.paginate(fetchFunction, 14);
+                    scope.isCollapsed = false;
+                }
+                else
+                    scope.dateError = true;
             };
 
             if(location.search().loanId != null){

--- a/app/views/accounting/search_transaction.html
+++ b/app/views/accounting/search_transaction.html
@@ -7,6 +7,7 @@
     <div class="card">
         <div class="content">
           <br>
+          <form name="searchtransactionform" ng-controller="SearchTransactionController" novalidate="" rc-submit="submit()">
             <div class="form-inline" ng-show="isCollapsed">
                 <div class="form-group">
                     <div class="form-group">
@@ -33,12 +34,17 @@
                     <h4 class="control-label ng-binding">{{'label.heading.daterange' | translate}}</h4>
                     <br>
                     <div class="form-group">
-                        <input class="form-control" type="text" datepicker-pop="dd MMMM yyyy" ng-model="date.first" is-open="opened" min="minDate" max="'2020-06-22'" placeholder="{{ 'label.input.fromdate' | translate }}" style="width: 155px;"/>
+                        <input id="fromDate" class="form-control" type="text" datepicker-pop="dd MMMM yyyy" ng-model="date.first" is-open="opened" min="minDate" max="maxDate" placeholder="{{ 'label.input.fromdate' | translate }}" style="width: 155px;"/>
                     </div>
                     <div class="form-group">
-                        <input class="form-control" type="text" datepicker-pop="dd MMMM yyyy" ng-model="date.second" is-open="opened1" min="minDate" max="'2020-06-22'" placeholder="{{ 'label.input.todate' | translate }}" style="width: 155px;"/>
+                        <input id="toDate" class="form-control" type="text" datepicker-pop="dd MMMM yyyy" ng-model="date.second" is-open="opened1" min="minDate" max="maxDate" placeholder="{{ 'label.input.todate' | translate }}" style="width: 155px;"/>
                     </div>
                 </div>
+                <br>
+                    <div class="col-sm-3">
+                        <span class="error" ng-if="dateError">{{ 'validation.msg.future.date.entered' | translate }}</span>
+                        <!-- <form-validate valattributeform="searchtransactionform" valattribute="toDate"/> -->
+                    </div>
                 <br>
                 <div class="form-group">
                     <h4 class="control-label ng-binding">{{'label.heading.transactionid' | translate}}</h4>
@@ -48,7 +54,7 @@
                             placeholder="{{'label.input.searchbytransaction' | translate}}" class="form-control"/>
                         </div>&nbsp;&nbsp;
                         <div class="form-group">
-                            <a ng-click="searchTransaction()" class="btn btn-primary btn-space pull-left btn-toolbar" has-permission='READ_JOURNALENTRY'> Search <i class="fa fa-search "></i></a>
+                            <button type="submit" class="btn btn-primary btn-space pull-left btn-toolbar" has-permission='READ_JOURNALENTRY'> Search <i class="fa fa-search "></i></button>
                         </div>
                 </div>
             </div>
@@ -115,6 +121,7 @@
                     <li class="next"><a id="next" ng-click="transactions.next()" href="" ng-disabled="!transactions.hasNext()">{{'label.button.next' | translate}} &rarr;</a></li>
                 </ul>
             </div>
+        </form>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Description
Restriction and validation have been added to "From date" and "To date" in "Search Journal Entries" so that user is aware when he/she types a future date.


## Related issues and discussion
#2907 

## Screenshots, if any
Future date disabled in "From date":
![community-app 2907 1](https://user-images.githubusercontent.com/29003134/36488796-5b6cba8c-174a-11e8-8fd7-1e2972acdac4.png)

Future date disabled in "To date":
![community-app 2907 2](https://user-images.githubusercontent.com/29003134/36488799-5c0d8b42-
174a-11e8-90f1-2fbe1f482f37.png)

Validation is present if future date is submitted:
![community-app 2907 3](https://user-images.githubusercontent.com/29003134/36488801-5c5b488c-174a-11e8-9367-4ee8987e527d.png)


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
