### PR TITLE
Fix #2916 Error log Message Overflow

### DIFF
--- a/app/styles-dev/main/components/_content.scss
+++ b/app/styles-dev/main/components/_content.scss
@@ -527,3 +527,7 @@ span.required {
 
   }
 }
+
+.pre-wrap {
+  white-space: pre-wrap;
+}

--- a/app/styles/styles.css
+++ b/app/styles/styles.css
@@ -7766,6 +7766,9 @@ span.required {
     .card .toolbar > .btn-group.btn-group-right {
       float: right; }
 
+.pre-wrap {
+  white-space: pre-wrap; }
+
 /* @import this file */
 .form-control {
   border-radius: 0;

--- a/app/views/system/schedulerjobs.html
+++ b/app/views/system/schedulerjobs.html
@@ -64,7 +64,7 @@
             	<h3 class="bolder">{{'label.heading.errorlog' | translate}}</h3>
         	</div>
         	<div class="modal-body">
-            	<p>{{error}}</p>
+            	<pre class="pre-wrap">{{error}}</pre>
         	</div>
         	<div class="modal-footer">
             	<button class="btn btn-warning" ng-click="cancel()">{{'label.button.close' | translate}}</button>

--- a/app/views/system/viewschedulerjobhistory.html
+++ b/app/views/system/viewschedulerjobhistory.html
@@ -53,7 +53,7 @@
             <h3 class="bolder">{{'label.heading.errorlog' | translate}}</h3>
         </div>
         <div class="modal-body">
-            <p>{{error}}</p>
+            <pre class="pre-wrap">{{error}}</pre>
         </div>
         <div class="modal-footer">
             <button class="btn btn-warning" ng-click="cancel()">{{'label.button.close' | translate}}</button>


### PR DESCRIPTION
## Description
Error log message is no longer overflowing out of the modal in scheduler jobs. Pre tag is added for better formatting and text is made to wrap in modal's body if the line is too long.

## Related issues and discussion
#2916 

## Screenshots, if any
![screenshot 530](https://user-images.githubusercontent.com/16948598/40190766-4dea3cac-5a1d-11e8-96d0-0d2c0362640b.png)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
