### PR TITLE
Fix broken new account wizards from eae7608

### DIFF
--- a/app/scripts/modules/angular-wizard.js
+++ b/app/scripts/modules/angular-wizard.js
@@ -69,8 +69,8 @@ angular.module('mgo-angular-wizard').directive('wzStep', function() {
                 $scope.title = $scope.wzTitle;
             });
             $scope.title = $scope.wzTitle;
-            if($element.find('.form-horizontal')[0].attributes['ng-submit']) {
-                $scope.formController = $element.find('.form-horizontal').controller("form");
+            if($element.find('form')[0].attributes['ng-submit']) {
+                $scope.formController = $element.find('form').controller("form");
             }
             wizard.addStep($scope);
             $scope.$on('$destroy', function(){


### PR DESCRIPTION
## Description
Due to changes made in eae7608, The new loan account and New share account wizards were not working, Hence changed the files so it works properly.

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
