### PR TITLE
Fixes issue #3001. datepicker disables dates before 1st Jan

### DIFF
--- a/app/views/system/makedatatableentry.html
+++ b/app/views/system/makedatatableentry.html
@@ -24,7 +24,7 @@
                            <input ng-show="fieldType(columnHeader.columnDisplayType) == 'TEXT'" type="text"
                                   ng-model="formData[columnHeader.columnName]" class="form-control"/>
                            <input ng-show="fieldType(columnHeader.columnDisplayType) == 'DATE'" type="text"
-                                  datepicker-pop="dd MMMM yyyy" ng-model="formDat[columnHeader.columnName]"
+                                  min="minDate" datepicker-pop="dd MMMM yyyy" ng-model="formDat[columnHeader.columnName]"
                                   is-open="opened{{$index}}" class="form-control"/>
                            <div ng-show="fieldType(columnHeader.columnDisplayType) == 'DATETIME'" class="form-inline">
                                <div class="form-group">

--- a/app/views/system/viewdatatableentry.html
+++ b/app/views/system/viewdatatableentry.html
@@ -49,7 +49,7 @@
                             <input ng-show="fieldType(columnHeader.columnDisplayType) == 'TEXT'" type="text"
                                    ng-model="formData[columnHeader.columnName]" class="form-control"/>
                             <input ng-show="fieldType(columnHeader.columnDisplayType) == 'DATE'" type="text"
-                                   datepicker-pop="dd MMMM yyyy" ng-model="formDat[columnHeader.columnName]"
+                                   min="minDate" datepicker-pop="dd MMMM yyyy" ng-model="formDat[columnHeader.columnName]"
                                    is-open="opened{{$index}}" class="form-control"/>
                             <div ng-show="fieldType(columnHeader.columnDisplayType) == 'DATETIME'" class="form-inline">
                                 <div class="form-group">


### PR DESCRIPTION
## Description
For the datatable date input field, min value was set to minDate. Issue was it was taking some default min value which was 1st of Jan of the current year so when the min value was explicitly set, it allows earlier dates.

## Related issues and discussion
#3001 

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
