### PR TITLE
Fix-3010 enable Post As on date for authorized user

### DIFF
--- a/app/scripts/controllers/savings/SavingAccountActionsController.js
+++ b/app/scripts/controllers/savings/SavingAccountActionsController.js
@@ -194,6 +194,7 @@
                     scope.modelName = 'transactionDate';
                     scope.showDateField = true;
                     scope.showAccountNumber=true;
+                    scope.taskPermissionName = 'POSTINTEREST_SAVINGSACCOUNT';
                     break;
                 case "withdrawal":
                     resourceFactory.savingsTrxnsTemplateResource.get({savingsId: scope.accountId}, function (data) {

--- a/app/scripts/controllers/savings/ViewSavingDetailsController.js
+++ b/app/scripts/controllers/savings/ViewSavingDetailsController.js
@@ -217,7 +217,7 @@
                         {
                             name: "button.postInterestAsOn",
                             icon: "icon-arrow-right",
-                            taskPermissionName:"POSTINTERESTASON_SAVINGSACCOUNT"
+                            taskPermissionName:"POSTINTEREST_SAVINGSACCOUNT"
                         },
                         {
                             name: "button.deposit",


### PR DESCRIPTION
## Description
Corrected the permission name from "POSTINTERESTASON_SAVINGSACCOUNT" to POSTINTEREST_SAVINGSACCOUNT, as there is no fineract code that supports POSTINTERESTASON action for SAVINGSACCOUNT. Instead this functionality is handled in  Post interest method only,  by passing parameter "isPostInterestAsOn" = true.

## Related issues and discussion
#3010 