### PR TITLE
fix3013 Readme bundler installation command Typo corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Travis
     npm install
    ```
    ```
-    bundler install
+    bundle install
    ```
 
 1. To preview the app, run the following command on the project root folder


### PR DESCRIPTION
## Description
Fixed The Bundler installation command Typo.

## Related issues and discussion
#3013 

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
