### PR TITLE
Account Usage is empty when editing the chart of account issue #2966

### DIFF
--- a/app/views/accounting/editglaccounting.html
+++ b/app/views/accounting/editglaccounting.html
@@ -53,8 +53,9 @@
 				<label class="control-label col-sm-2 " for="usage">{{'label.input.accountusage' | translate}}</label>
 
 				<div class="col-sm-2">
-					<select id="usage" ng-model="formData.usage" class="form-control">
-						<option ng-repeat="usageType in usageTypes" value="{{usageType.id}}">{{''+usageType.code+'' | translate}}</option>
+					<select id="usage" ng-model="formData.usage" class="form-control"
+						ng-options="usageType.id as usageType.code | translate for usageType in usageTypes" value="{{usageType.id}}"
+							 required="required">
 					</select>
 				</div>
 				<label class="control-label col-sm-4 " for="tagId">{{'label.input.tag' | translate}}</label>


### PR DESCRIPTION
## Description
Account Usage is empty when editing the chart of account 

## Related issues and discussion
#2966

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
