### PR TITLE
Fix #2335 - Make description field non-mandatory in create RD/FD product

### DIFF
--- a/app/views/products/createfixeddepositproduct.html
+++ b/app/views/products/createfixeddepositproduct.html
@@ -32,13 +32,10 @@
                         </div>
                     </div>
                     <div class="form-group">
-                        <label class="control-label col-sm-2">{{ 'label.input.description' | translate }}<span class="required">*</span></label>
+                        <label class="control-label col-sm-2">{{ 'label.input.description' | translate }}</label>
                         <div class="col-sm-2">
                             <textarea rows="2" id="description" name="description" ng-model="formData.description"
-                                      class="form-control" required late-validate></textarea>
-                        </div>
-                        <div class="col-sm-2">
-                            <form-validate valattributeform="Details" valattribute="description"/>
+                                      class="form-control" ></textarea>
                         </div>
                     </div>
                     <hr>


### PR DESCRIPTION
## Description
Make description field non-mandatory in create RD/FD product.

## Related issues and discussion
#2335

## Screenshots
- Before
![screenshot from 2018-11-07 05-12-06](https://user-images.githubusercontent.com/28915865/48101058-c4624800-e24b-11e8-894b-03a85495b4f3.png)
- After
![screenshot from 2018-11-07 05-08-38](https://user-images.githubusercontent.com/28915865/48101070-d0e6a080-e24b-11e8-9bff-ce214a16e782.png)


## Checklist

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
