### PR TITLE
Editting Employee mobile Number for SMS Should only allow numeric

### DIFF
--- a/app/views/organization/editemployee.html
+++ b/app/views/organization/editemployee.html
@@ -64,7 +64,15 @@
                         <label class="control-label col-sm-2" for="mobileNo">{{ 'label.input.mobileNo' | translate }}</label>
 
                         <div class="col-sm-3">
-                            <input type="text" id="mobileNo" class="form-control" ng-model="formData.mobileNo">
+                            <input type="text" id="mobileNo" name="mobileNo" ng-model="formData.mobileNo"
+                                   ng-pattern="/^[0-9]+$/"  class="form-control"/>
+                        </div>
+                        <div class="col-sm-2">
+                        <span ng-show="editemployeeform.mobileNo.$invalid && editemployeeform.mobileNo.$dirty">
+                        <small class="required" ng-show="editemployeeform.mobileNo.$error.pattern">
+                        {{'label.mustbenumeric' | translate}}
+                        </small>
+                        </span>
                         </div>
                     </div>
 


### PR DESCRIPTION
## Description
 Mobile Number for SMS field in Editting Employee allow user to enter text while it  Should only allow numeric and show error otherwise, as exmplained in issues #2962

## Related issues and discussion
#2962

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
