### PR TITLE
Fixes #3003 - Penalties Receivable tooltip

### DIFF
--- a/app/global-translations/locale-en.json
+++ b/app/global-translations/locale-en.json
@@ -1523,7 +1523,7 @@
   "label.tooltip.loanportfolio": "an Asset account that is debited during disbursement and credited during principal repayment/writeoff.",
   "label.tooltip.receivableinterest": "an Asset account that is used to accrue interest",
   "label.tooltip.receivablefees": "an Asset account that is used to accrue fees",
-  "label.tooltip.receivablepnalties": "an Asset account that is used to accrue penalties",
+  "label.tooltip.receivablepenalties": "an Asset account that is used to accrue penalties",
   "label.tooltip.transfersinsuspense": "an Asset account that is used a suspense account for tracking portfolios of loans under transfer.",
   "label.tooltip.incomefrominterest": "an Income account that is credited during interest payment.",
   "label.tooltip.incomefromfees": "an Income account that is credited during fee payment.",


### PR DESCRIPTION
## Description
Fixed a small typo in `app/global-translations/locale-en.json` to show the correct tooltip for Penalties Receivable field

## Related issues and discussion
#3003 

## Screenshots
![screenshot from 2018-11-08 10-17-59](https://user-images.githubusercontent.com/16154204/48178462-a6760f80-e33f-11e8-8ab8-8b4224db7af0.png)


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
