### PR TITLE
Country was not showing in Client's address page in issue 

### DIFF
--- a/app/views/administration/AddressForm.html
+++ b/app/views/administration/AddressForm.html
@@ -101,7 +101,7 @@
 
             </div>
 
-            <div class="form-group" ng-show="country">
+            <div class="form-group" ng-show="countryId">
                 <div class="control-label col-sm-2">
                     <label>{{ 'label.input.country' | translate }}</label>
                 </div>


### PR DESCRIPTION
## Description
Resolved the countries selection problem by pointing out the list from empty list stateOptions to countryOptions

## Related issues and discussion
#3019

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
