### PR TITLE
Feat #2935 - Add UI for editing submitted on date for groups

### DIFF
--- a/app/scripts/controllers/groups/CreateGroupController.js
+++ b/app/scripts/controllers/groups/CreateGroupController.js
@@ -167,8 +167,7 @@
                     scope.formData.clientMembers[i] = scope.addedClients[i].id;
                 }
                 if (this.formData.active) {
-                    var reqDate = dateFilter(scope.first.date, scope.df);
-                    this.formData.activationDate = reqDate;
+                    this.formData.activationDate = dateFilter(scope.first.date, scope.df);
                 }
                 if (routeParams.centerId) {
                     this.formData.centerId = routeParams.centerId;
@@ -177,8 +176,7 @@
                     this.formData.officeId = routeParams.officeId;
                 }
                 if (scope.first.submitondate) {
-                    reqDat = dateFilter(scope.first.submitondate, scope.df);
-                    this.formData.submittedOnDate = reqDat;
+                    this.formData.submittedOnDate = dateFilter(scope.first.submitondate, scope.df);
                 }
                 this.formData.locale = scope.optlang.code;
                 this.formData.dateFormat = scope.df;

--- a/app/scripts/controllers/groups/EditGroupController.js
+++ b/app/scripts/controllers/groups/EditGroupController.js
@@ -117,12 +117,13 @@
             resourceFactory.groupResource.get({groupId: routeParams.id}, function (data) {
                 if (data.timeline.submittedOnDate) {
                     scope.mindate = new Date(data.timeline.submittedOnDate);
+                    scope.first.submitondate = new Date(dateFilter(data.timeline.submittedOnDate, scope.df));
                 }
             });
 
             scope.updateGroup = function () {
-                var reqDate = dateFilter(scope.first.date, scope.df);
-                this.formData.activationDate = reqDate;
+                this.formData.submittedOnDate = dateFilter(scope.first.submitondate, scope.df);
+                this.formData.activationDate = dateFilter(scope.first.date, scope.df);
                 this.formData.locale = scope.optlang.code;
                 this.formData.dateFormat = scope.df;
                 resourceFactory.groupResource.update({groupId: routeParams.id}, this.formData, function (data) {

--- a/app/views/groups/editgroup.html
+++ b/app/views/groups/editgroup.html
@@ -43,6 +43,14 @@
                                     <input type="text" id="externalId" ng-model="formData.externalId" class="form-control"/>
                                 </div>
                             </div>
+                            <div class="form-group">
+                                <label class="control-label col-sm-2">{{'label.input.submittedon' | translate}}:</label>
+
+                                <div class="col-sm-3">
+                                    <input id="submittedon" type="text" name="submittedon" datepicker-pop="dd MMMM yyyy"
+                                           ng-model="first.submitondate" is-open="opened1" min="'2000-01-01'" max="restrictDate" class="form-control"/>
+                                </div>
+                            </div>
                             <div ng-hide="editGroup.status.value == 'Pending'">
                                 <div class="form-group">
                                     <label class="control-label col-sm-2">{{'label.input.activationdate' | translate}}<span class="required">*</span></label>


### PR DESCRIPTION
## Description
Add UI for editing **submitted on** date for groups.

## Related issues and discussion
#2935

## Screenshots, if any
![screenshot from 2018-12-12 03-17-26](https://user-images.githubusercontent.com/28915865/49832677-5aded780-fdbd-11e8-8d13-8aee8543d5d3.png)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
