### PR TITLE
Cashier Recap Does Not Display  Groups  Operations  #3065

### DIFF
--- a/app/global-translations/locale-en.json
+++ b/app/global-translations/locale-en.json
@@ -4254,5 +4254,6 @@
   "reportRunFrequency.monthly": "Monthly",
   "reportRunFrequency.yearly": "Yearly",
   "reportRunFrequency.custom": "Custom",
+  "label.heading.activate.group": "Activate Group",
   "----End---": "--End of file--- "
 }

--- a/app/scripts/controllers/groups/EditGroupController.js
+++ b/app/scripts/controllers/groups/EditGroupController.js
@@ -1,6 +1,6 @@
 (function (module) {
     mifosX.controllers = _.extend(module, {
-        EditGroupController: function (scope, resourceFactory, location, routeParams, dateFilter) {
+        EditGroupController: function (scope, resourceFactory, location, routeParams, dateFilter, WizardHandler) {
             scope.first = {};
             scope.managecode = routeParams.managecode;
             scope.restrictDate = new Date();
@@ -187,7 +187,7 @@
             };
         }
     });
-    mifosX.ng.application.controller('EditGroupController', ['$scope', 'ResourceFactory', '$location', '$routeParams', 'dateFilter', mifosX.controllers.EditGroupController]).run(function ($log) {
+    mifosX.ng.application.controller('EditGroupController', ['$scope', 'ResourceFactory', '$location', '$routeParams', 'dateFilter','WizardHandler', mifosX.controllers.EditGroupController]).run(function ($log) {
         $log.info("EditGroupController initialized");
     });
 }(mifosX.controllers || {}));

--- a/app/scripts/directives/ScrollableDirective.js
+++ b/app/scripts/directives/ScrollableDirective.js
@@ -70,8 +70,7 @@ Reference from JSfiddle : https://jsfiddle.net/sonicblis/2afea34h/9/
 
                    function onNavTabsMouseDown($event) {
                        var currentlyScrollable = element.classList.contains('scrollable');
-                       console.log(currentlyScrollable);
-
+                  
                        if (currentlyScrollable === true) {
                            $event.preventDefault();
 
@@ -88,7 +87,6 @@ Reference from JSfiddle : https://jsfiddle.net/sonicblis/2afea34h/9/
                    }
 
                    function checkForScroll(){
-                       console.log('checking tabs for scroll');
                        var currentlyScrollable = element.classList.contains('scrollable'),
                            difference = 1;
 
@@ -133,7 +131,6 @@ Reference from JSfiddle : https://jsfiddle.net/sonicblis/2afea34h/9/
                    }
 
                    $scope.$on('checkTabs', function(){
-                       console.log("tabcheck");
                        $timeout(checkForScroll, 10); });
 
                    function init() {

--- a/app/views/groups/editgroup.html
+++ b/app/views/groups/editgroup.html
@@ -1,81 +1,91 @@
 <div class="content-container" ng-controller="EditGroupController">
+<div class="content-container" data-ng-controller="MemberManageController">
+    <ul class="breadcrumb">
+        <li><a href="#/groups">{{'label.anchor.groups' | translate}}</a></li>
+        <li><a href="#/viewgroup/{{group.id}}">{{'label.anchor.viewgroup' | translate}}</a></li>
+    </ul>
     <wizard current-step="step" on-finish="submitDatatable()">
-        <div data-ng-switch on="managecode" class="card well">
-            <wz-step wz-title="{{'label.heading.editgroup' | translate}}">
-        <form name="editgroupform" novalidate="" class="form-horizontal" rc-submit="updateGroup()"
-              data-ng-switch-when="1">
-            <fieldset>
-                <api-validate></api-validate>
-                <!--<legend>{{'label.heading.editgroup' | translate}}</legend>-->
-                <div class="form-group">
-                    <label class="control-label col-sm-2" for="name">{{'label.input.name' | translate}}<span
-                            class="required">*</span></label>
+        <div class="card well">
+         <wz-step wz-title="{{'label.heading.details' | translate}}">
+                <div ng-show="managecode == 1">
+               
+                    <form name="editgroupform" novalidate="" class="form-horizontal" ng-submit="updateGroup()">
+                        <fieldset>
+                            <api-validate></api-validate>
+                            <legend>{{'label.heading.editgroup' | translate}}</legend>
+                            <div class="form-group">
+                                <label class="control-label col-sm-2" for="name">{{'label.input.name' | translate}}<span
+                                        class="required">*</span></label>
 
-                    <div class="col-sm-3">
-                        <input ng-autofocus="true" type="text" id="name" name="name" placeholder="{{editGroup.name}}"
-                               ng-model="formData.name" class="form-control" required late-Validate/>
-                    </div>
-                    <div class="col-sm-3">
-                        <form-validate valattributeform="editgroupform" valattribute="name"/>
-                    </div>
+                                <div class="col-sm-3">
+                                    <input ng-autofocus="true" type="text" id="name" name="name" placeholder="{{editGroup.name}}"
+                                           ng-model="formData.name" class="form-control" required late-Validate/>
+                                </div>
+                                <div class="col-sm-3">
+                                    <form-validate valattributeform="editgroupform" valattribute="name"/>
+                                </div>
+                            </div>
+                            <div class="form-group info">
+                                <label class="control-label col-sm-2" for="staffId">{{'label.input.staff' | translate}}</label>
+
+                                <div class="col-sm-3">
+                                    <select chosen="editGroup.staffOptions" id="staffId" ng-model="formData.staffId"
+                                            data-ng-options="staff.id as staff.displayName for staff in editGroup.staffOptions"
+                                            value="{{staff.id}}" class="form-control">
+                                        <option value="">{{'label.menu.selectstaff' | translate}}</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="form-group">
+                                <label class="control-label col-sm-2" for="externalid">{{'label.input.externalid' | translate}}</label>
+
+                                <div class="col-sm-3">
+                                    <input type="text" id="externalId" ng-model="formData.externalId" class="form-control"/>
+                                </div>
+                            </div>
+                            <div ng-hide="editGroup.status.value == 'Pending'">
+                                <div class="form-group">
+                                    <label class="control-label col-sm-2">{{'label.input.activationdate' | translate}}<span class="required">*</span></label>
+
+                                    <div class="col-sm-3">
+                                        <input type="text" datepicker-pop="dd MMMM yyyy" ng-model="first.date" is-open="opened"
+                                               min="'2000-01-01'" max="restrictDate" class="form-control"/>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-md-offset-3">
+                                <a href="#/viewgroup/{{editGroup.id}}" class="btn btn-default">{{'label.button.cancel' | translate}}</a>
+                                <button type="submit" class="btn btn-primary" has-permission='UPDATE_GROUP'>{{'label.button.save' | translate}}</button>
+                            </div>
+                        </fieldset>
+                    </form>
                 </div>
-                <div class="form-group info">
-                    <label class="control-label col-sm-2" for="staffId">{{'label.input.staff' | translate}}</label>
-
-                    <div class="col-sm-3">
-                        <select chosen="editGroup.staffOptions" id="staffId" ng-model="formData.staffId"
-                                data-ng-options="staff.id as staff.displayName for staff in editGroup.staffOptions"
-                                value="{{staff.id}}" class="form-control">
-                            <option value="">{{'label.menu.selectstaff' | translate}}</option>
-                        </select>
-                    </div>
-                </div>
-                <div class="form-group">
-                    <label class="control-label col-sm-2" for="externalid">{{'label.input.externalid' | translate}}</label>
-
-                    <div class="col-sm-3">
-                        <input type="text" id="externalId" ng-model="formData.externalId" class="form-control"/>
-                    </div>
-                </div>
-                <div ng-hide="editGroup.status.value == 'Pending'">
-                    <div class="form-group">
-                        <label class="control-label col-sm-2">{{'label.input.activationdate' | translate}}<span class="required">*</span></label>
-
-                        <div class="col-sm-3">
-                            <input type="text" datepicker-pop="dd MMMM yyyy" ng-model="first.date" is-open="opened"
-                                   min="'2000-01-01'" max="restrictDate" class="form-control"/>
+                <div ng-show="managecode == 2">
+                    <legend>{{'label.heading.activate.group' | translate}}</legend>
+                    <form class="form-horizontal card well">
+                        <div class="form-group">
+                            <label class="control-label col-sm-2">{{ 'label.input.enteractivationdate' | translate }}<span
+                                        class="required">*</span></label>
+                            <div class="col-sm-3">
+                                <input id="activationDate" type="text" datepicker-pop="dd MMMM yyyy" ng-model="first.date"
+                                       is-open="opened" min="mindate" max="restrictDate" required class="form-control"/>
+                            </div>
                         </div>
-                    </div>
-                </div>
-                <div class="col-md-offset-3">
-                    <a href="#/viewgroup/{{editGroup.id}}" class="btn btn-default">{{'label.button.cancel' | translate}}</a>
-                    <button type="submit" class="btn btn-primary" has-permission='UPDATE_GROUP'>{{'label.button.save' | translate}}</button>
-                </div>
-            </fieldset>
-        </form>
-        <form class="form-horizontal card well" ng-switch-when="2">
-            <div class="form-group">
-                <label class="control-label col-sm-2">{{ 'label.input.enteractivationdate' | translate }}<span
-                            class="required">*</span></label>
-                <div class="col-sm-3">
-                    <input id="activationDate" type="text" datepicker-pop="dd MMMM yyyy" ng-model="first.date"
-                           is-open="opened" min="mindate" max="restrictDate" required class="form-control"/>
-                </div>
-            </div>
-            <div class="form-group">
-                <button id="save1"  wz-next class="btn btn-primary pull-right" ng-show="isEntityDatatables">
-                    {{'label.button.proceed' | translate}}
-                </button>
+                        <div class="form-group">
+                            <button id="save1"  wz-next class="btn btn-primary pull-right" ng-show="isEntityDatatables">
+                                {{'label.button.proceed' | translate}}
+                            </button>
 
-                <div class="col-sm-3 col-md-offset-2" ng-hide="isEntityDatatables">
-                    <a id="cancel" href="#/viewgroup/{{editGroup.id}}" class="btn btn-default">{{'label.button.cancel' | translate}}</a>
-                    <button id="save" type="button" class="btn btn-primary" wz-next ><i
-                            class="fa fa-check-sign " has-permission='ACTIVATE_GROUP'></i>{{ 'label.button.activate' | translate }}
-                    </button>
-                </div>
+                            <div class="col-sm-3 col-md-offset-2" ng-hide="isEntityDatatables">
+                                <a id="cancel" href="#/viewgroup/{{editGroup.id}}" class="btn btn-default">{{'label.button.cancel' | translate}}</a>
+                                <button id="save" type="button" class="btn btn-primary" wz-next ><i
+                                        class="fa fa-check-sign " has-permission='ACTIVATE_GROUP'></i>{{ 'label.button.activate' | translate }}
+                                </button>
+                            </div>
 
-            </div>
-        </form>
+                        </div>
+                    </form>
+                </div>
             </wz-step>
             <wz-step ng-if="isEntityDatatables" ng-repeat="datatable in datatables" wz-title="{{datatable.registeredTableName}}">
                 <div class="card-content">
@@ -152,6 +162,6 @@
                     </form>
                 </div>
             </wz-step>
-            </div>
+        </div>
     </wizard>
 </div>


### PR DESCRIPTION

## Description
when a cashier does a cashier operation for the groups it does not appear in his details of his day's operation. but the other operations outside the group appear well. then your tasks would be to make them appear and calculate the net balance.


## Related issues and discussion
in this table only the simple client operations are supported. when the notebook does an operation in a group it does not appear suddenly the net it holds and what displays do not match

## Screenshots, 
example the cashier makes deposit and withdrawal transactions for individual customers and when you go to the Admin -> Organization -> Teller / Cashier Management -> cashier menu, the operation is well detailed. however, when the operation is for a group (deposit / withdrawal) it does not appear labas. so the calculation is not clear

![recapcaisse](https://user-images.githubusercontent.com/11898877/50014117-a85b7000-ff88-11e8-9e2c-b4f2b74f9218.PNG)
