### PR TITLE
Fix-3066 multiple address created on getting and correcting validatio…

### DIFF
--- a/app/scripts/controllers/client/CreateClientController.js
+++ b/app/scripts/controllers/client/CreateClientController.js
@@ -314,6 +314,7 @@
 
                 if(scope.enableAddress===true)
                 {
+                    scope.formData.address = [];
                     for(var i=0;i<scope.addressArray.length;i++)
                     {
                         var temp=new Object();


### PR DESCRIPTION
…n message

## Description
Emptied address array on clicking submit . address  details were pushed to array whenever submit was clicked, but was not emptied when the exception was thrown, this resulted in same object copy to the address array.

## Related issues and discussion
#3066 

