### PR TITLE
FIX-1687 datatable date and time issues

### DIFF
--- a/app/scripts/controllers/system/DataTableEntryController.js
+++ b/app/scripts/controllers/system/DataTableEntryController.js
@@ -100,7 +100,7 @@
                         if(scope.columnHeaders[i].value != null) {
                             scope.formDat[scope.columnHeaders[i].columnName] = {
                                 date: dateFilter(new Date(scope.columnHeaders[i].value), scope.df),
-                                time: dateFilter(new Date(scope.columnHeaders[i].value), scope.tf)
+                                time: new Date(scope.columnHeaders[i].value)
                             };
                         }
                     } else {


### PR DESCRIPTION
## Description
fixed time field in edit datatable

## Related issues and discussion
#1687 

Angular js versions above 1.2 doesn't support string values for input type 'time'. It expects date object in model for input type-time.
