### PR TITLE
configurations changes related to whitelabel on Mifos login page-White Label

### DIFF
--- a/app/global-translations/locale-en.json
+++ b/app/global-translations/locale-en.json
@@ -479,7 +479,7 @@
   "label.heading.fullname": "Name",
   "label.heading.mifosxclient": "Mifos X Client",
   "label.heading.mifosx": "Mifos X",
-  "label.heading.uptodate": "Mifos X is up to date",
+  "label.heading.uptodate": " is up to date",
   "label.heading.resources": "Resources",
   "label.heading.community": "Community",
   "label.heading.contribute": "Contribute",

--- a/app/index.html
+++ b/app/index.html
@@ -192,10 +192,10 @@
 
                 </div>
 
-
+                <div class="row" ng-hide = "response.uiDisplayConfigurations.whiteLabel.loginPage.hideCommunityDetails">
                 <hr/>
-
-                <div class="row">
+                
+                <div class="row" >
                     <div class="col-xs-4 text-center">
 
                         <ul class="list-unstyled">
@@ -247,6 +247,7 @@
                 </div>
 
                 <hr/>
+            
                 <div class="row">
                     <div class="col-sm-6 col-sm-offset-3 text-center">
                         <br>
@@ -258,10 +259,13 @@
 
                     </div>
                 </div>
+            </div>
+            <div class="row" ng-hide = "response.uiDisplayConfigurations.whiteLabel.loginPage.releaseDetails">
                 <p class="text-center text-muted small">
                     <span>{{ 'label.heading.version' | translate }} {{ version }}</span>
-                    <br/> <span>{{ 'label.heading.uptodate' | translate }}</span>
+                    <br/> <span>{{response.uiDisplayConfigurations.whiteLabel.loginPage.companyName}}{{ 'label.heading.uptodate' | translate }}</span>
                 </p>
+            </div>
             </div>
         </div>
     </div>

--- a/app/scripts/config/UIconfig.json
+++ b/app/scripts/config/UIconfig.json
@@ -29,6 +29,13 @@
 	  "isReadOnlyField": {
 		"loanTermFrequencyType": true
 	  }
+	},
+	"whiteLabel": {
+		"loginPage":{
+			"hideCommunityDetails": false,
+			"releaseDetails": false,
+			"companyName": "Mifos"
+		}
 	}
   }
 }

--- a/app/scripts/controllers/main/MainController.js
+++ b/app/scripts/controllers/main/MainController.js
@@ -44,6 +44,8 @@
                     }
                 });
             }
+            
+
 
             scope.$on('scrollbar.show', function(){
                   console.log('Scrollbar show');
@@ -52,7 +54,12 @@
                   console.log('Scrollbar hide');
                 });
 
-            uiConfigService.init();
+            uiConfigService.init(scope);
+            
+            
+            scope.$on('configJsonObj',function(e,response){
+                scope.response = response;
+            });
             //hides loader
             scope.domReady = true;
             scope.activity = {};

--- a/app/scripts/services/UIConfigService.js
+++ b/app/scripts/services/UIConfigService.js
@@ -3,7 +3,6 @@
 
         UIConfigService: function ($q,$http,$templateCache) {
             this.appendConfigToScope = function(scope){
-
                 var jsonData = $templateCache.get("configJsonObj");
                 if(jsonData != null && jsonData != ""){
                     jsonData.then(function(data) {
@@ -16,9 +15,10 @@
                 }
             };
 
-            this.init  = function() {
+            this.init  = function(scope) {
                 var deferred = $q.defer();
                 $http.get('scripts/config/UIconfig.json').success(function(data) {
+                    scope.$emit("configJsonObj",data);
                     deferred.resolve(data);
                     $templateCache.put("configJsonObj", deferred.promise);
                 }).error(function(data) {


### PR DESCRIPTION
Added new fields in UIConfig.json which are used to white label the "community-App"

This Pull request consists of following white label features:
1. hide Mifos community related details from login page => (set "hideCommunityDetails" field to **true** in UIConfig.json file if you want to hide the details related to community)

2. Dynamic company name(name that populates in release related information) configuration in  UIConfig.json

3. Hide release related details from login page( set "releaseDetails" field to **true** in UIConfig.json file if you want to hide the release details from login page).