### PR TITLE
Fixing travis build failures (bump node version to 5)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-   - "0.10"
+   - "5"
 before_install:
   - mkdir travis-phantomjs
   - wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2


### PR DESCRIPTION
## Description
Fixing Travis build failures by bumping node version to 5

## Related issues and discussion
NA

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [ ] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `community-app/Contributing.md`.
