### PR TITLE
Dockerize Community App

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM timbru31/ruby-node:2.5 as builder
+
+RUN mkdir /usr/src/app
+WORKDIR /usr/src/app
+ENV PATH /usr/src/app/node_modules/.bin:$PATH
+COPY package.json /usr/src/app/package.json
+
+RUN npm install -g bower
+RUN npm install -g grunt-cli
+COPY . /usr/src/app
+RUN bower --allow-root install
+RUN npm install
+RUN bundle install
+RUN grunt prod
+
+FROM nginx:1.16.0
+COPY --from=builder /usr/src/app/dist/community-app /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -119,6 +119,21 @@ Start a static server and open the project in the default browser. The applicati
 ```
 grunt serve
 ```
+
+### Docker
+To build a Docker image for the current repo, run:
+```
+docker build -t mifos-community-app .
+```
+You can then run a Docker Container from the image above like this:
+```
+docker run --name mifos-ui -it -d -p 80:80 mifos-community-app
+```
+
+Access the webapp on http://localhost in your browser. Ma
+The Dockerfile uses a ruby and node base image to build the current repo and deploys the app on nginx which is exposed 
+port 80 within the container
+
 ### Compile sass to css
 
 ```


### PR DESCRIPTION
Dockerize Community App.
Update readme with intructions on how to build.
Docker image is created and app is run in nginx when image is executed.

Fix #3106 