### PR TITLE
Fix #3119 - Enable Hidden Fields When Creating and Updating a Loan Account

### DIFF
--- a/app/scripts/config/UIconfig.json
+++ b/app/scripts/config/UIconfig.json
@@ -1,33 +1,33 @@
 {
-  "enableUIDisplayConfiguration": false,
+  "enableUIDisplayConfiguration": true,
   "uiDisplayConfigurations": {
 	"loanAccount": {
 	  "isHiddenField": {
-		"fundId": true,
-		"linkAccountId": true,
-		"createStandingInstruction": true,
-		"numberOfRepayments": true,
-		"repaymentEvery": true,
-		"repaymentFrequencyType": true,
-		"repaymentFrequencyNthDayType": true,
-		"repaymentFrequencyDayOfWeekType": true,
-		"interestChargedFromDate": true,
-		"repaymentsStartingFromDate": true,
-		"interestType": true,
-		"amortizationType": true,
-		"interestCalculationPeriodType": true,
-		"inArrearsTolerance": true,
-		"graceOnInterestCharged": true,
-		"transactionProcessingStrategyId": true,
-		"graceOnInterestPayment": true,
-		"graceOnArrearsAgeing": true
+		"fundId": false,
+		"linkAccountId": false,
+		"createStandingInstruction": false,
+		"numberOfRepayments": false,
+		"repaymentEvery": false,
+		"repaymentFrequencyType": false,
+		"repaymentFrequencyNthDayType": false,
+		"repaymentFrequencyDayOfWeekType": false,
+		"interestChargedFromDate": false,
+		"repaymentsStartingFromDate": false,
+		"interestType": false,
+		"amortizationType": false,
+		"interestCalculationPeriodType": false,
+		"inArrearsTolerance": false,
+		"graceOnInterestCharged": false,
+		"transactionProcessingStrategyId": false,
+		"graceOnInterestPayment": false,
+		"graceOnArrearsAgeing": false
 	  },
 	  "isHiddenSection": {
-		"interestRecalculationSection": true,
-		"collateralSection": true
+		"interestRecalculationSection": false,
+		"collateralSection": false
 	  },
 	  "isReadOnlyField": {
-		"loanTermFrequencyType": true
+		"loanTermFrequencyType": false
 	  }
 	},
 	"whiteLabel": {


### PR DESCRIPTION
## Description
By default, lots of input fields related to Loan Application are hidden which should not be the case.

Issue is seen on both create new loan or edit. For below screenshots, try editing a loan application (sample):
_URL: https://demo.openmf.org#/editloanaccount/3355_

## Related issues and discussion
#3119 

## Screenshots, if any
**Before (lots of field are missing):**

<img width="1181" alt="Screen Shot 2019-10-03 at 8 49 10 AM" src="https://user-images.githubusercontent.com/50645323/66091602-00686f00-e5bb-11e9-8706-88cc9f994ca3.png">

**After (or expected):**

<img width="1287" alt="Screen Shot 2019-10-03 at 8 52 36 AM" src="https://user-images.githubusercontent.com/50645323/66091667-4c1b1880-e5bb-11e9-8944-8fde612fd4bf.png">


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
