### PR TITLE
adds the meaningful label against the button "Activate Self Service User"

### DIFF
--- a/app/views/selfservice/createuser.html
+++ b/app/views/selfservice/createuser.html
@@ -121,7 +121,7 @@
                         <input type="submit" value="{{'label.button.activateselfservice' | translate }}" ng-disabled="accountActive" ng-class="accountActive ? 'btn btn-md btn-disabled' : 'btn btn-md btn-primary' "/>
                     </div>
                     <div class="col-sm-2">
-                        <a uib-tooltip="{{'label.button.selfserviceactivatehelp' | translate}}" class="ng-binding">
+                        <a uib-tooltip="{{'Activate Self Service User Help' | translate}}" class="ng-binding">
                                 <i class="fa fa-question-circle fa-2x"></i>
                         </a>
                     </div>


### PR DESCRIPTION
## Description
Added meaningful tool tip for help link in 'Create Self user page' .

## Related issues and discussion
#3139 

## Screenshots, if any
![Capture d’écran (164)](https://user-images.githubusercontent.com/38397893/70090853-3eb1f700-161b-11ea-8df7-16e68b83d55a.png)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
