### PR TITLE
Fix #2350 - Disables previous and next month calendar dates

### DIFF
--- a/app/styles/styles.css
+++ b/app/styles/styles.css
@@ -8983,6 +8983,7 @@ input[type="submit"] {
 button[disabled],
 html input[disabled] {
   cursor: default;
+  opacity: 50%;
 }
 
 /* line 311, ../bower_components/bootstrap-sass/assets/stylesheets/bootstrap/_normalize.scss */


### PR DESCRIPTION
## Description
Disabled previous and next month calendar dates on selection of a month in every calendar in the app.

## Related issues and discussion
#2350 

## Screenshots, if any
before:
![Clipboard01](https://user-images.githubusercontent.com/38397893/70380177-6c5ab100-1937-11ea-9581-80ca24c8b97c.jpg)

after:
![Clipboard01](https://user-images.githubusercontent.com/38397893/70386554-df950f00-1999-11ea-8946-09e44536088f.jpg)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
