### PR TITLE
fix: remove erroneous error message when uploading client image

### DIFF
--- a/app/scripts/controllers/client/ViewClientController.js
+++ b/app/scripts/controllers/client/ViewClientController.js
@@ -287,9 +287,9 @@
                             file: file
                         }).then(function (imageData) {
                             // to fix IE not refreshing the model
-                            if (!scope.$$phase) {
+                            $timeout(function () {
                                 scope.$apply();
-                            }
+                            });
                             $uibModalInstance.close('upload');
                             route.reload();
                         });


### PR DESCRIPTION
Per FINERACT-666 bug (https://issues.apache.org/jira/browse/FINERACT-666),
user may get a "field is required" message when trying to upload a valid image
file if they have previously tried to upload an invalid file type such as .txt.

Root cause seems to be ViewClientController is check the scope phase before
applying scope.  Instead, recommended practice is to apply the scope within
a timeout block (ref https://stackoverflow.com/questions/12729122/angularjs-prevent-error-digest-already-in-progress-when-calling-scope-apply).
Upon changing to use timeout(), the above issue is fixed.

Fixes: FINERACT-666

## Description
Describe the changes made and why they were made instead of how they were made.

## Related issues and discussion
#FINERACT-666

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [X ] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [X ] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [X ] If you have multiple commits please combine them into one commit by squashing them.

- [X ] Read and understood the contribution guidelines at `community-app/Contributing.md`.
