### PR TITLE
Fix #2729 - Fixes edit button not aligned properly

### DIFF
--- a/app/views/products/viewloanproduct.html
+++ b/app/views/products/viewloanproduct.html
@@ -16,7 +16,7 @@
                        class="fa fa-edit "></i>&nbsp;&nbsp;{{'label.button.edit' | translate}}</a>
                 </div>
             </div>
-            <legend>{{loanproduct.name}}</legend>
+            <legend class="paddedtop paddedbottom10">{{loanproduct.name}}</legend>
 <table width="100%">
 <tr>
     <td>


### PR DESCRIPTION
## Description
Aligned the button properly in the title of the loan products page.

## Related issues and discussion
#2729 

## Screenshots, if any
Before: 
![Capture d’écran (207)](https://user-images.githubusercontent.com/38397893/71323280-a9937700-24d1-11ea-9d10-c01868ef271b.png)

After:
![Capture d’écran (208)](https://user-images.githubusercontent.com/38397893/71328082-4f1a0b00-2511-11ea-9cde-dbc368b27eef.png)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
