### PR TITLE
Fix #3070 - Fixes wrong group display

### DIFF
--- a/app/scripts/controllers/centers/CreateCenterController.js
+++ b/app/scripts/controllers/centers/CreateCenterController.js
@@ -20,7 +20,9 @@
 
             scope.getGroups = function() {
                 resourceFactory.groupResource.getAllGroups({officeId: scope.formData.officeId }, function (data) {
-                    scope.groups = data;
+                    scope.groups = data.filter(function (group) {
+                        return !group.centerId;
+                    });
                 });
             }
 


### PR DESCRIPTION
## Description
Made the application only show the groups which are not part of other centers when creating a center.
## Related issues and discussion
#3070 

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
