### PR TITLE
chore: replace sqlSearch with status param in checker inbox for clients

### DIFF
--- a/app/scripts/controllers/main/TaskController.js
+++ b/app/scripts/controllers/main/TaskController.js
@@ -332,7 +332,7 @@
             });
 
 
-            resourceFactory.clientResource.getAllClients({sqlSearch: 'c.status_enum=100'}, function (data) {
+            resourceFactory.clientResource.getAllClients({status: 'pending'}, function (data) {
                 scope.groupedClients = _.groupBy(data.pageItems, "officeName");
             });
 

--- a/app/scripts/services/ResourceFactoryProvider.js
+++ b/app/scripts/services/ResourceFactoryProvider.js
@@ -47,8 +47,8 @@
                     importResource: defineResource(apiVer + "/imports", {}, {
                 			getImports: {method: 'GET', params: {}, isArray: true}
                     }),
-                    clientResource: defineResource(apiVer + "/clients/:clientId/:anotherresource", {clientId: '@clientId', anotherresource: '@anotherresource', sqlSearch: '@sqlSearch'}, {
-                        getAllClients: {method: 'GET', params: {limit: 1000, sqlSearch: '@sqlSearch'}},
+                    clientResource: defineResource(apiVer + "/clients/:clientId/:anotherresource", {clientId: '@clientId', anotherresource: '@anotherresource', status: '@status'}, {
+                        getAllClients: {method: 'GET', params: {limit: 1000, status: '@status'}},
                         getAllClientsWithoutLimit: {method: 'GET', params: {}},
                         getClientClosureReasons: {method: 'GET', params: {}},
                         getAllClientDocuments: {method: 'GET', params: {}, isArray: true},


### PR DESCRIPTION
## Description
We were using the `sqlSearch` parameter for filtering out clients of status `pending` in checker inbox, which wasn't very flexible in terms of usage, so it was decided that we eliminate this parameter and introduce `status` parameter (only usage of `sqlSearch`). For more info about the new parameter, please refer to this [PR in Fineract](https://github.com/apache/fineract/pull/1207).

## Note
Please set baseApiUrl to `demo.fineract.dev` while testing this PR.

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits, please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.