### PR TITLE
#2225 - hide recovery payment button when written off amount is zero

### DIFF
--- a/app/global-translations/locale-en.json
+++ b/app/global-translations/locale-en.json
@@ -1813,6 +1813,7 @@
   "validation.msg.rescheduleloan.rescheduleReasonId.cannot.be.blank": "Reason for Rescheduling cannot be empty",
   "validation.msg.rescheduleloan.loan.reschedule.interestrecalculation.error.code": "Error in Recalculation of Interest",
   "validation.msg.rescheduleloan.rescheduleFromDate.adjustedDueDate.before.rescheduleFromDate": "Installment Rescheduled to can not be before  Rescheduled from date.",
+  "error.msg.loan.transaction.cannot.be.greater.than.total.written.off": "Repayment amount cannot be greater than the total written off.",
   "#-------": "------------",
   "#Savings and Deposit accounts": "....",
   "#Headings": "..",

--- a/app/scripts/controllers/loanAccount/ViewLoanDetailsController.js
+++ b/app/scripts/controllers/loanAccount/ViewLoanDetailsController.js
@@ -391,7 +391,7 @@
                     ]
                     };
                 }
-                if (data.status.value == "Closed (written off)") {
+                if ((data.status.value == "Closed (written off)") && (data.summary.totalWrittenOff > 0)) {
                     scope.buttons = { singlebuttons: [
                         {
                             name: "button.recoverypayment",


### PR DESCRIPTION
## Description
per #2225 
1. hide recovery payment button in viewloandetailscontroller.js if the total_written_off amount <= 0.
2. added a string for validation error when the user tries to enter a repayment amount greater than the total written off.  this validation error will be returned by the API in a corresponding PR for fineract.

## Related issues and discussion
#2225 

## Screenshots, if any
![image](https://user-images.githubusercontent.com/10203461/94635070-c7330f80-029f-11eb-9f4f-1e1b35763692.png)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [X ] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [ X] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [X ] If you have multiple commits please combine them into one commit by squashing them.

- [ X] Read and understood the contribution guidelines at `community-app/Contributing.md`.
