### PR TITLE
Fix #3308: Fixed savings account dropdown in client new share account page

### DIFF
--- a/app/scripts/controllers/shares/CreateShareAccountController.js
+++ b/app/scripts/controllers/shares/CreateShareAccountController.js
@@ -15,6 +15,17 @@
                 scope.inparams.clientId = scope.clientId
             }
             scope.disabled = true;
+
+            resourceFactory.clientAccountResource.get({clientId:scope.inparams.clientId}, function(savingsData){
+                scope.savingsData = savingsData.savingsAccounts.filter(function(savings){
+                    return savings.status.active;
+                })
+            })
+
+            resourceFactory.chargeResource.getAllCharges(function(chargesData){
+                scope.chargeOptions = chargesData;
+            })
+
             resourceFactory.shareAccountTemplateResource.get(scope.inparams, function (data) {
                 scope.products = data.productOptions;
                 scope.chargeOptions = data.chargeOptions;
@@ -76,6 +87,7 @@
                 this.formData.locale = scope.optlang.code;
                 this.formData.dateFormat = scope.df;
                 this.formData.charges = [];
+                this.formData.savingsAccountId = this.formData.savingsAccountId.toString();
 
                 if (scope.clientId) this.formData.clientId = scope.clientId;
                 if (scope.charges.length > 0) {

--- a/app/views/shares/createshareaccount.html
+++ b/app/views/shares/createshareaccount.html
@@ -131,9 +131,9 @@
                                     </label>
                                 </td>
                                 <td class="width36 paddedbottom20">
-                                    <select id="savingsAccountId" ng-model="formData.savingsAccountId" ng-options="savingsAccount.id as savingsAccount.accountNo for savingsAccount in data.clientSavingsAccounts"
-                                        ng-change="sharedetails.savingsAccountNo = formValue(data.clientSavingsAccount,formData.savingsAccountId,'id','accountNo')"
-                                        value="{{savingsAccount.id}}" class="form-control width170px">
+                                    <select id="savingsAccountId" ng-model="formData.savingsAccountId" ng-options="savingsAccount.id as savingsAccount.accountNo for savingsAccount in savingsData"
+                                        ng-change="sharedetails.savingsAccountNo = formValue(savingsData,formData.savingsAccountId,'id','accountNo')"
+                                        class="form-control width170px" value="{{savingsAccount.id}}">
                                         <option value="">{{'label.selectone' | translate}}</option>
                                     </select>
                                 </td>


### PR DESCRIPTION
## Description
Fixed options for active savings account field in client->new share account page.

## Related issues and discussion
#3308 

## Screenshots, if any
![Screenshot from 2020-10-31 21-01-35](https://user-images.githubusercontent.com/43112139/97783766-cef81380-1bbf-11eb-9046-2e6b8d0e4f36.png)


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
