### PR TITLE
undoing fix #3196

### DIFF
--- a/app/scripts/filters/DateFormat.js
+++ b/app/scripts/filters/DateFormat.js
@@ -3,9 +3,13 @@
         DateFormat: function (dateFilter, localStorageService) {
             return function (input) {
                 if (input) {
-                    // SAFARI is Bad We fix it
-                    remove = input.toString().split(",");
-                    var tDate = new Date(remove[0], remove[1]-1, remove[2]);
+                    // SAFARI is Bad We fix it Issue #3196
+                    // This fix affected transaction
+                    //remove = input.toString().split(",");
+                    //var tDate = new Date(remove[0], remove[1]-1, remove[2]);
+                    //return dateFilter(tDate, localStorageService.getFromLocalStorage('dateformat'));
+
+                    var tDate = new Date(input);
                     return dateFilter(tDate, localStorageService.getFromLocalStorage('dateformat'));
                 }
                 return '';

--- a/app/views/savings/view_saving_account_details.html
+++ b/app/views/savings/view_saving_account_details.html
@@ -467,7 +467,7 @@
                             </thead>
                             <tbody>
                             <tr class="pointer-main" ng-hide="transaction.reversed"
-                                ng-repeat="transaction in savingaccountdetails.transactions | orderBy:transactionSort.column:transactionSort.descending">
+                                ng-repeat="transaction in savingaccountdetails.transactions | orderBy:transactionSort.column[2]:transactionSort.ascending">
                                 <td class="pointer"
                                     data-ng-click="routeTo(transaction.accountId,transaction.id,transaction.transfer,transaction.transfer.id)">
                                     {{transaction.id}}


### PR DESCRIPTION
## Description
When a transaction occurs (under any type of savings account: fixed deposit, recurring deposit or regular savings account and Loan Accounts), the date displays as null under transactions tab. Drilling down by clicking on the transaction however shows the correct date

## Related issues and discussion
#3206 

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [ ] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `community-app/Contributing.md`.
