### PR TITLE
Fixed edit tax-group field in edit-charge component

### DIFF
--- a/app/views/products/editcharge.html
+++ b/app/views/products/editcharge.html
@@ -169,7 +169,7 @@
                     <select id="taxGroupId" ng-model="formData.taxGroupId"
                             chosen="template.taxGroupOptions"
                             ng-options="taxGroup.id as taxGroup.name for taxGroup in template.taxGroupOptions"
-                            value="{{taxGroup.id}}" disabled="disabled">
+                            value="{{taxGroup.id}}">
                     </select>
                 </div>
             </div>


### PR DESCRIPTION
## Description
Tax Group field cannot be edited during a charge edit

## Related issues and discussion
#3337 

## Screenshots, if any

Adding a charge without specifying a tax group
![Screenshot from 2021-03-03 09-20-24](https://user-images.githubusercontent.com/43112139/109750145-e85aac00-7c01-11eb-84ff-d3943787aa18.png)

Edit Charge UI
![Screenshot from 2021-03-03 09-20-34](https://user-images.githubusercontent.com/43112139/109750193-00323000-7c02-11eb-8136-fd581ab77cd9.png)

After editing the loan charge
![Screenshot from 2021-03-03 09-20-43](https://user-images.githubusercontent.com/43112139/109750221-0c1df200-7c02-11eb-99e0-654e3db03b64.png)



## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [ ] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
