### PR TITLE
Fix #3202 - the Account usage should be displayed as 'Detail' by default

### DIFF
--- a/app/views/accounting/createglaccounting.html
+++ b/app/views/accounting/createglaccounting.html
@@ -52,9 +52,10 @@
 	            <label class="control-label col-sm-2 " for="usage">{{'label.input.accountusage' | translate}}</label>
 	
 	            <div class="col-sm-2">
-					<select id="usage" ng-model="formData.usage" class="form-control">
-						<option ng-repeat="usageType in usageTypes" value="{{usageType.id}}">{{''+usageType.code+'' | translate}}</option>
-					</select>
+					<select  id="usage" ng-model="formData.usage" class="form-control"
+                           ng-options="usageType.id as usageType.value for usageType in usageTypes" value="{{usageType.id}}">
+                    </select>
+					
 	            </div>
 	            <label class="control-label col-sm-4 " for="tagId">{{'label.input.tag' | translate}}</label>
 	            <div class="col-sm-2">


### PR DESCRIPTION
## Description
the Account usage should be displayed as 'Detail' by default

## Related issues and discussion
#3202

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [ ] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `community-app/Contributing.md`.
