### PR TITLE
Fixes DOM text reinterpreted as HTML vulnerability detected by CodeQL

### DIFF
--- a/.project
+++ b/.project
@@ -5,7 +5,24 @@
 	<projects>
 	</projects>
 	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1687118378909</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/app/scripts/controllers/reports/XBRLReportController.js
+++ b/app/scripts/controllers/reports/XBRLReportController.js
@@ -3,25 +3,32 @@
         XBRLReportController: function (scope, resourceFactory, location, $rootScope) {
 
             scope.xmlData = $rootScope.xmlData;
-            var html = "<table width='100%' border='1'><tr><th>Title</th><th>Dimension</th><th>Value</th></tr>";
+            var table = $("<table width='100%' border='1'></table>");
+            var header = $("<tr></tr>").append("<th>Title</th>", "<th>Dimension</th>", "<th>Value</th>");
+            table.append(header);
+            
             $(scope.xmlData).find("*[contextRef]").each(function (i) {
                 var contextId = $(this).attr("contextRef");
                 var context = $(scope.xmlData).find("#" + contextId).find("scenario").text();
-                html += '<tr>';
-                html += '<td>' + this.tagName + '</td>';
-                html += '<td>' + context + '</td>';
+                
+                var row = $("<tr></tr>");
+                row.append('<td>' + this.tagName + '</td>');
+                row.append('<td>' + context + '</td>');
+
                 var inputId = this.tagName + "|" + contextId;
-                html += '<td><input type="text" class="report" id="' + inputId + '" value="' + $(this).text() + '" ></td>';
-                html += '</tr>';
+                var input = $('<td><input type="text" class="report"></td>');
+                input.find('input').attr('id', inputId).val($(this).text());
+                row.append(input);
+
+                table.append(row);
             });
-            $("#xbrlreport").html(html);
+            
+            $("#xbrlreport").empty().append(table);
 
             scope.saveReport = function () {
                 var string = (new XMLSerializer()).serializeToString(scope.xmlData);
                 window.location.href = 'data:Application/octet-stream;Content-Disposition:attachment;filename=file.xml,' + escape(string);
             };
-
-
         }
     });
     mifosX.ng.application.controller('XBRLReportController', ['$scope', 'ResourceFactory', '$location', '$rootScope', mifosX.controllers.XBRLReportController]).run(function ($log) {


### PR DESCRIPTION
## Description
This fix creates jQuery objects for each HTML element and sets their attributes and text content separately, which ensures that no untrusted string can be interpreted as HTML. This way, even if inputId or $(this).text() are controlled by a user and contain malicious script, they will be treated as plain text and not executed as script which prevents injection attacks.

## Related issues and discussion
#3526 

## Screenshots, if any
![image](https://github.com/openMF/community-app/assets/32770175/49ecef42-1422-404d-9fec-f71b18533067)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.
giving network error #3519 
- [] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
