### PR TITLE
Fix Overwritten Property in CreateGroupController.js

### DIFF
--- a/app/scripts/controllers/groups/CreateGroupController.js
+++ b/app/scripts/controllers/groups/CreateGroupController.js
@@ -118,7 +118,7 @@
             scope.changeOffice = function (officeId) {
                 scope.addedClients = [];
                 scope.clientData.available = [];
-                resourceFactory.groupTemplateResource.get({staffInSelectedOfficeOnly: false, officeId: officeId,staffInSelectedOfficeOnly:true
+                resourceFactory.groupTemplateResource.get({officeId: officeId,staffInSelectedOfficeOnly:true
                 }, function (data) {
                     scope.staffs = data.staffOptions;
                 });


### PR DESCRIPTION
## Description
This PR fixes the issue by setting staffInSelectedOfficeOnly to true only once.

## Related issues and discussion
#3530

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
