### PR TITLE
Fix #3539 - fix lien parameter name

### DIFF
--- a/app/scripts/controllers/savings/HoldSavingsAccountController.js
+++ b/app/scripts/controllers/savings/HoldSavingsAccountController.js
@@ -86,7 +86,7 @@
                 var params = {command: scope.action};
                 this.formData.locale = scope.optlang.code;
                 this.formData.dateFormat = scope.df;
-                this.formData.lien = this.formData.lien || false;
+                this.formData.lienAllowed = this.formData.lienAllowed || false;
                 this.formData.transactionDate = dateFilter(this.formData.transactionDate, scope.df);
 
                 if(scope.holdOption == 'savingsAccountBlock') {


### PR DESCRIPTION
## Description
The name of the parameter "lien" has been changed to "lienAllowed " in this PR, as the old name of the parameter "lien" was not supported during hold account request for the hold type "Savings Transaction Freeze" (POST request /fineract-provider/api/v1/savingsaccounts/1/transactions?command=holdAmount).

## Related issues and discussion
[#{3539}](https://github.com/openMF/community-app/issues/3539)

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Validate the JS and HTML files with `grunt validate` to detect errors and potential problems in JavaScript code.

- [x] Run the tests by opening `test/SpecRunner.html` in the browser to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `community-app/Contributing.md`.
